### PR TITLE
hotfix: 회원가입/로그인 401 문제 해결

### DIFF
--- a/src/main/java/com/example/emotion_storage/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/emotion_storage/global/config/security/SecurityConfig.java
@@ -4,7 +4,6 @@ import com.example.emotion_storage.global.security.jwt.JwtAuthEntryPoint;
 import com.example.emotion_storage.global.security.jwt.JwtTokenProvider;
 import com.example.emotion_storage.global.security.jwt.TokenAuthenticationFilter;
 import com.example.emotion_storage.user.repository.UserRepository;
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -38,6 +37,8 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**",
+                                "/api/v1/users/login/**",
+                                "/api/v1/users/signup/**",
                                 "/docs/**",
                                 "/health",
                                 "/h2-console/**",

--- a/src/main/java/com/example/emotion_storage/global/security/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/example/emotion_storage/global/security/jwt/TokenAuthenticationFilter.java
@@ -30,6 +30,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     // 화이트리스트
     private final List<String> whitelist = List.of(
             "/auth",
+            "/api/v1/users/signup",
+            "/api/v1/users/login",
             "/docs",
             "/health",
             "/h2-console",


### PR DESCRIPTION
## ✨ 작업 내용
- 프론트에서 구글 회원가입 시도 시에 401 오류 발생
- 오류 원인: permitAll 누락으로 ID 토큰 검증 이전에 Security 레이어에서 401 차단되는 문제 발생
- 조치:
  - SecurityConfig: signup/login 허용
  - TokenAuthenticationFilter: 화이트 리스트에 회원가입, 로그인 엔드포인트 추가
  
---

## 📝 적용 범위
- `global/config/security/SecurityConfig`
- `global/security/jwt/TokenAuthenticationFilter`

---

## 📌 참고 사항
- 관련 이슈(#27)