### PR TITLE
hotfix: 구글 회원가입 시 성별 누락한 부분 수정

### DIFF
--- a/src/main/java/com/example/emotion_storage/user/service/UserService.java
+++ b/src/main/java/com/example/emotion_storage/user/service/UserService.java
@@ -61,6 +61,7 @@ public class UserService {
                 .socialType(SocialType.GOOGLE)
                 .profileImageUrl(claims.profileImgUrl())
                 .nickname(request.nickname())
+                .gender(request.gender())
                 .birthday(request.birthday())
                 .expectations(request.expectations())
                 .isTermsAgreed(request.isTermsAgreed())


### PR DESCRIPTION
## ✨ 작업 내용
- 구글 회원가입 시 성별을 저장하지 않아 500 에러가 발생한 부분 수정

---

## 📝 적용 범위
- `user/controller/UserController`

---

## 📌 참고 사항
- 관련 이슈(#30)