### PR TITLE
feat: 카카오 로그인, 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 	implementation 'com.google.oauth-client:google-oauth-client:1.34.0'
 	implementation 'com.google.http-client:google-http-client-gson:1.41.0'
 	implementation 'com.google.guava:guava:33.1.0-jre'
+
+	// H2
+	runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.security:spring-security-oauth2-jose'
+	testImplementation "org.springframework.security:spring-security-test"
 
 	// Google
 	implementation 'com.google.api-client:google-api-client:1.34.0'

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum SuccessMessage {
     LOGIN_SUCCESS("로그인 성공"),
     SIGNUP_SUCCESS("회원가입 성공"),
-    ACCESS_TOKEN_REISSUE_SUCCESS("액세스 토큰 재발급 성공");
+    ACCESS_TOKEN_REISSUE_SUCCESS("액세스 토큰 재발급 성공"),
+    SESSION_CHECK_SUCCESS("세션 확인 성공");
 
     private final String message;
 }

--- a/src/main/java/com/example/emotion_storage/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/emotion_storage/global/config/security/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                 .headers(h -> h.frameOptions(FrameOptionsConfig::sameOrigin)) // H2 콘솔 접근 시 iframe 사용 허용 (동일 출처만 허용하여 보안 유지)
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/session").authenticated()
                         .requestMatchers("/auth/**",
                                 "/api/v1/users/login/**",
                                 "/api/v1/users/signup/**",

--- a/src/main/java/com/example/emotion_storage/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/emotion_storage/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     ALREADY_REGISTERED_WITH_GOOGLE(HttpStatus.BAD_REQUEST, "해당 이메일은 구글로 가입된 계정입니다."),
     ALREADY_REGISTERED_WITH_KAKAO(HttpStatus.BAD_REQUEST, "해당 이메일은 카카오로 가입된 계정입니다."),
     INVALID_ID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 ID TOKEN 입니다."),
+    INVALID_KAKAO_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 카카오 Access Token 입니다."),
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 Access Token 입니다."),
     ACCESS_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 Access Token 입니다."),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 Refresh Token 입니다."),

--- a/src/main/java/com/example/emotion_storage/global/security/jwt/TokenAuthenticationFilter.java
+++ b/src/main/java/com/example/emotion_storage/global/security/jwt/TokenAuthenticationFilter.java
@@ -54,6 +54,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
 
         if (token == null || token.isBlank()) {
+            SecurityContextHolder.clearContext();
             filterChain.doFilter(request, response);
             return;
         }
@@ -73,6 +74,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
                     new UsernamePasswordAuthenticationToken(principal, null, authorities);
             SecurityContextHolder.getContext().setAuthentication(authenticationToken);
         } else {
+            SecurityContextHolder.clearContext();
             ErrorCode errorCode = (status == TokenStatus.EXPIRED)
                     ? ErrorCode.ACCESS_TOKEN_EXPIRED
                     : ErrorCode.ACCESS_TOKEN_INVALID;

--- a/src/main/java/com/example/emotion_storage/user/auth/controller/AuthController.java
+++ b/src/main/java/com/example/emotion_storage/user/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.example.emotion_storage.user.auth.controller;
 import com.example.emotion_storage.global.api.ApiResponse;
 import com.example.emotion_storage.global.api.SuccessMessage;
 import com.example.emotion_storage.user.auth.dto.response.AccessTokenResponse;
+import com.example.emotion_storage.user.auth.dto.response.SessionResponse;
 import com.example.emotion_storage.user.auth.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -35,5 +36,15 @@ public class AuthController {
         String accessToken = tokenService.reissueAccessToken(httpServletRequest, httpServletResponse);
         AccessTokenResponse response = AccessTokenResponse.from(accessToken);
         return ApiResponse.success(HttpStatus.OK.value(), SuccessMessage.ACCESS_TOKEN_REISSUE_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "세션 유지 확인", description = "액세스 토큰으로 로그인 세션 정보를 확인합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "세션 정보 확인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "액세스 토큰 만료")
+    })
+    @PostMapping("/session")
+    public ApiResponse<SessionResponse> checkSession() {
+        return ApiResponse.success(SuccessMessage.SESSION_CHECK_SUCCESS.getMessage(), SessionResponse.ok());
     }
 }

--- a/src/main/java/com/example/emotion_storage/user/auth/controller/AuthController.java
+++ b/src/main/java/com/example/emotion_storage/user/auth/controller/AuthController.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,12 +39,12 @@ public class AuthController {
         return ApiResponse.success(HttpStatus.OK.value(), SuccessMessage.ACCESS_TOKEN_REISSUE_SUCCESS.getMessage(), response);
     }
 
-    @Operation(summary = "세션 유지 확인", description = "액세스 토큰으로 로그인 세션 정보를 확인합니다.")
+    @Operation(summary = "세션 유지 확인", description = "Authorization 헤더의 액세스 토큰이 유효한지 확인합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "세션 정보 확인 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "액세스 토큰 만료")
     })
-    @PostMapping("/session")
+    @GetMapping("/session")
     public ApiResponse<SessionResponse> checkSession() {
         return ApiResponse.success(SuccessMessage.SESSION_CHECK_SUCCESS.getMessage(), SessionResponse.ok());
     }

--- a/src/main/java/com/example/emotion_storage/user/auth/dto/response/SessionResponse.java
+++ b/src/main/java/com/example/emotion_storage/user/auth/dto/response/SessionResponse.java
@@ -1,0 +1,9 @@
+package com.example.emotion_storage.user.auth.dto.response;
+
+public record SessionResponse(
+        boolean success
+) {
+    public static SessionResponse ok() {
+        return new SessionResponse(true);
+    }
+}

--- a/src/main/java/com/example/emotion_storage/user/auth/oauth/kakao/KakaoUserInfo.java
+++ b/src/main/java/com/example/emotion_storage/user/auth/oauth/kakao/KakaoUserInfo.java
@@ -1,0 +1,25 @@
+package com.example.emotion_storage.user.auth.oauth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserInfo(
+        Long id,
+        @JsonProperty("connected_at")
+        String connectedAt,
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+            KakaoProfile profile,
+            String email // 비즈 계정에서만 가능
+    ) {}
+
+    public record KakaoProfile(
+            @JsonProperty("profile_image_url")
+            String profileImgUrl
+    ) {}
+
+    public String getKakaoId() {
+        return id.toString();
+    }
+}

--- a/src/main/java/com/example/emotion_storage/user/auth/oauth/kakao/KakaoUserInfoClient.java
+++ b/src/main/java/com/example/emotion_storage/user/auth/oauth/kakao/KakaoUserInfoClient.java
@@ -1,0 +1,42 @@
+package com.example.emotion_storage.user.auth.oauth.kakao;
+
+import com.example.emotion_storage.global.exception.BaseException;
+import com.example.emotion_storage.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoUserInfoClient {
+
+    private static final String KAKAO_USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+    private static final String BEARER_HEADER_FORMAT = "Bearer %s";
+
+    private final RestClient restClient;
+
+    public KakaoUserInfo getKakaoUserInfo(String accessToken) {
+        try {
+            KakaoUserInfo userInfo = restClient.get()
+                    .uri(KAKAO_USER_INFO_URI)
+                    .header(HttpHeaders.AUTHORIZATION, makeBearerFormat(accessToken))
+                    .retrieve()
+                    .body(KakaoUserInfo.class);
+
+            if (userInfo.id() == null) {
+                throw new BaseException(ErrorCode.INVALID_KAKAO_ACCESS_TOKEN);
+            }
+
+            return userInfo;
+
+        } catch (RestClientResponseException e) {
+            throw new BaseException(ErrorCode.INVALID_KAKAO_ACCESS_TOKEN);
+        }
+    }
+
+    private String makeBearerFormat(String accessToken) {
+        return String.format(BEARER_HEADER_FORMAT, accessToken);
+    }
+}

--- a/src/main/java/com/example/emotion_storage/user/auth/oauth/kakao/config/KakaoConfig.java
+++ b/src/main/java/com/example/emotion_storage/user/auth/oauth/kakao/config/KakaoConfig.java
@@ -1,0 +1,14 @@
+package com.example.emotion_storage.user.auth.oauth.kakao.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class KakaoConfig {
+
+    @Bean
+    public RestClient kakaoRestClient(RestClient.Builder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/com/example/emotion_storage/user/controller/UserController.java
+++ b/src/main/java/com/example/emotion_storage/user/controller/UserController.java
@@ -4,6 +4,8 @@ import com.example.emotion_storage.global.api.ApiResponse;
 import com.example.emotion_storage.global.api.SuccessMessage;
 import com.example.emotion_storage.user.dto.request.GoogleLoginRequest;
 import com.example.emotion_storage.user.dto.request.GoogleSignUpRequest;
+import com.example.emotion_storage.user.dto.request.KakaoLoginRequest;
+import com.example.emotion_storage.user.dto.request.KakaoSignUpRequest;
 import com.example.emotion_storage.user.dto.response.LoginResponse;
 import com.example.emotion_storage.user.dto.response.SignupResponse;
 import com.example.emotion_storage.user.service.UserService;
@@ -50,6 +52,32 @@ public class UserController {
     @PostMapping("/signup/google")
     public ApiResponse<SignupResponse> signupWithGoogle(@RequestBody GoogleSignUpRequest request) {
         userService.googleSignUp(request);
+        return ApiResponse.success(HttpStatus.CREATED.value(), SuccessMessage.SIGNUP_SUCCESS.getMessage(), SignupResponse.ok());
+    }
+
+    @Operation(summary = "카카오 로그인", description = "카카오 액세스 토큰으로 로그인합니다. 리프레시 토큰은 HttpOnly 쿠키로 설정됩니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "로그인 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "회원가입 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 액세스 토큰"),
+            //@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "다른 소셜로 이미 가입")
+    })
+    @PostMapping("/login/kakao")
+    public ApiResponse<LoginResponse> loginWithKakao(
+            @RequestBody KakaoLoginRequest request, HttpServletResponse httpServletResponse) {
+        LoginResponse response = userService.kakaoLogin(request, httpServletResponse);
+        return ApiResponse.success(HttpStatus.CREATED.value(), SuccessMessage.LOGIN_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "카카오 회원가입", description = "카카오 액세스 토큰 검증 후 신규 회원을 생성합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 액세스 토큰"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 가입된 계정")
+    })
+    @PostMapping("/signup/kakao")
+    public ApiResponse<SignupResponse> signupWithKakao(@RequestBody KakaoSignUpRequest request) {
+        userService.kakaoSignUp(request);
         return ApiResponse.success(HttpStatus.CREATED.value(), SuccessMessage.SIGNUP_SUCCESS.getMessage(), SignupResponse.ok());
     }
 }

--- a/src/main/java/com/example/emotion_storage/user/domain/User.java
+++ b/src/main/java/com/example/emotion_storage/user/domain/User.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -68,5 +69,8 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean isPrivacyAgreed;
 
+    @Column(nullable = false)
     private boolean isMarketingAgreed;
+
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/example/emotion_storage/user/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/example/emotion_storage/user/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,5 @@
+package com.example.emotion_storage.user.dto.request;
+
+public record KakaoLoginRequest(
+        String accessToken
+) {}

--- a/src/main/java/com/example/emotion_storage/user/dto/request/KakaoSignUpRequest.java
+++ b/src/main/java/com/example/emotion_storage/user/dto/request/KakaoSignUpRequest.java
@@ -1,0 +1,16 @@
+package com.example.emotion_storage.user.dto.request;
+
+import com.example.emotion_storage.user.domain.Gender;
+import java.time.LocalDate;
+import java.util.List;
+
+public record KakaoSignUpRequest(
+        String nickname,
+        Gender gender,
+        LocalDate birthday,
+        List<String> expectations,
+        boolean isTermsAgreed,
+        boolean isPrivacyAgreed,
+        boolean isMarketingAgreed,
+        String accessToken
+) {}

--- a/src/main/java/com/example/emotion_storage/user/repository/UserRepository.java
+++ b/src/main/java/com/example/emotion_storage/user/repository/UserRepository.java
@@ -9,5 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+    Optional<User> findBySocialId(String socialId);
     Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/emotion_storage/user/service/UserService.java
+++ b/src/main/java/com/example/emotion_storage/user/service/UserService.java
@@ -128,6 +128,7 @@ public class UserService {
                 .socialType(SocialType.KAKAO)
                 .profileImageUrl(userInfo.kakaoAccount().profile().profileImgUrl())
                 .nickname(request.nickname())
+                .gender(request.gender())
                 .birthday(request.birthday())
                 .expectations(request.expectations())
                 .isTermsAgreed(request.isTermsAgreed())

--- a/src/test/java/com/example/emotion_storage/global/config/TestSecurityConfig.java
+++ b/src/test/java/com/example/emotion_storage/global/config/TestSecurityConfig.java
@@ -13,7 +13,9 @@ public class TestSecurityConfig {
     public SecurityFilterChain testSecurityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/session").authenticated()
+                        .anyRequest().permitAll());
         return httpSecurity.build();
     }
 }

--- a/src/test/java/com/example/emotion_storage/user/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/emotion_storage/user/auth/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package com.example.emotion_storage.user.auth.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -56,5 +58,15 @@ public class AuthControllerTest {
                 .andExpect(jsonPath("$.status").value(401))
                 .andExpect(jsonPath("$.code").value("REFRESH_TOKEN_NOT_FOUND"))
                 .andExpect(jsonPath("$.message").value(ErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage()));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "USER")
+    void 액세스_토큰이_유효하면_success_true가_반환된다() throws Exception {
+        mockMvc.perform(get("/auth/session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value(SuccessMessage.SESSION_CHECK_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.success").value(true));
     }
 }

--- a/src/test/java/com/example/emotion_storage/user/controller/UserControllerTest.java
+++ b/src/test/java/com/example/emotion_storage/user/controller/UserControllerTest.java
@@ -14,6 +14,8 @@ import com.example.emotion_storage.global.exception.ErrorCode;
 import com.example.emotion_storage.user.domain.Gender;
 import com.example.emotion_storage.user.dto.request.GoogleLoginRequest;
 import com.example.emotion_storage.user.dto.request.GoogleSignUpRequest;
+import com.example.emotion_storage.user.dto.request.KakaoLoginRequest;
+import com.example.emotion_storage.user.dto.request.KakaoSignUpRequest;
 import com.example.emotion_storage.user.dto.response.LoginResponse;
 import com.example.emotion_storage.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -196,6 +198,132 @@ public class UserControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/v1/users/signup/google")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("ALREADY_REGISTERED_WITH_KAKAO"))
+                .andExpect(jsonPath("$.message").value(ErrorCode.ALREADY_REGISTERED_WITH_KAKAO.getMessage()));
+    }
+
+    @Test
+    void 카카오_로그인_성공할_때는_액세스_토큰을_반환한다() throws Exception {
+        // given
+        given(userService.kakaoLogin(any(KakaoLoginRequest.class), any(HttpServletResponse.class)))
+                .willReturn(new LoginResponse("access-token"));
+
+        // when, then
+        mockMvc.perform(post("/api/v1/users/login/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new KakaoLoginRequest("kakao-access-token"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.message").value(SuccessMessage.LOGIN_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"));
+    }
+
+    @Test
+    void 카카오_로그인_시에_회원가입이_되어있지_않다면_예외가_발생한다() throws Exception {
+        // given
+        given(userService.kakaoLogin(any(KakaoLoginRequest.class), any(HttpServletResponse.class)))
+                .willThrow(new BaseException(ErrorCode.NEED_SIGN_UP));
+
+        // when, then
+        mockMvc.perform(post("/api/v1/users/login/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new KakaoLoginRequest("kakao-access-token"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.code").value("NEED_SIGN_UP"))
+                .andExpect(jsonPath("$.message").value(ErrorCode.NEED_SIGN_UP.getMessage()));
+    }
+
+    @Test
+    void 카카오_로그인_시에_카카오_ACCESS_TOKEN이_유효하지_않다면_예외가_발생한다() throws Exception {
+        // given
+        given(userService.kakaoLogin(any(KakaoLoginRequest.class), any(HttpServletResponse.class)))
+                .willThrow(new BaseException(ErrorCode.INVALID_KAKAO_ACCESS_TOKEN));
+
+        // when, then
+        mockMvc.perform(post("/api/v1/users/login/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new KakaoLoginRequest("bad-token"))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.code").value("INVALID_KAKAO_ACCESS_TOKEN"))
+                .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_KAKAO_ACCESS_TOKEN.getMessage()));
+    }
+
+    @Test
+    void 카카오_회원가입이_성공하면_success_true를_반환한다() throws Exception {
+        // given
+        KakaoSignUpRequest request = new KakaoSignUpRequest(
+                "모이",
+                Gender.MALE,
+                LocalDate.of(2000, 1, 1),
+                List.of("내 감정을 정리하고 싶어요", "내 감정 패턴을 알고 싶어요"),
+                true,
+                true,
+                false,
+                "kakao-access-token"
+        );
+
+        // when, then
+        mockMvc.perform(post("/api/v1/users/signup/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk()) // HTTP 200
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.message").value(SuccessMessage.SIGNUP_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.success").value(true));
+    }
+
+    @Test
+    void 카카오_회원가입_시에_카카오_ACCESS_TOKEN이_유효하지_않다면_예외가_발생한다() throws Exception {
+        // given
+        doThrow(new BaseException(ErrorCode.INVALID_KAKAO_ACCESS_TOKEN))
+                .when(userService)
+                .kakaoSignUp(any(KakaoSignUpRequest.class));
+
+        KakaoSignUpRequest request = new KakaoSignUpRequest(
+                "모이",
+                Gender.FEMALE,
+                LocalDate.of(1990, 1, 1),
+                List.of("내 감정을 정리하고 싶어요"),
+                true,
+                true,
+                false,
+                "kakao-access-token"
+        );
+
+        // when, then
+        mockMvc.perform(post("/api/v1/users/signup/kakao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.code").value("INVALID_KAKAO_ACCESS_TOKEN"))
+                .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_KAKAO_ACCESS_TOKEN.getMessage()));
+    }
+
+    @Test
+    void 카카오_회원가입_시에_이미_카카오로_가입된_계정으로_회원가입을_시도하면_예외가_발생한다() throws Exception {
+        // given
+        doThrow(new BaseException(ErrorCode.ALREADY_REGISTERED_WITH_KAKAO))
+                .when(userService)
+                .kakaoSignUp(any(KakaoSignUpRequest.class));
+
+        KakaoSignUpRequest request = new KakaoSignUpRequest(
+                "모이",
+                Gender.MALE,
+                LocalDate.of(2000,1,1),
+                List.of(),
+                true, true, false,
+                "kakao-access-token"
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v1/users/signup/kakao")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())


### PR DESCRIPTION
## ✨ 작업 내용
- 카카오 액세스 토큰으로 로그인 및 회원가입 기능 구현
- Swagger 주석으로 문서화
- 카카오 로그인 및 회원가입 테스트 코드 추가
- `user/session` 엔드포인트 추가
- User 엔티티에 `deletedAt` 추가

---

## 📝 적용 범위
- `build.gradle`
- `global/api/SuccessMessage`, `global/config/exception/SecurityConfig`,  `global/config/exception/ErrorCode`, `global/security/jwt/TokenAuthenticationFilter`
- `user/auth/controller/AuthController`, `user/auth/dto/response/SessionResponse`, `/user/auth/oauth/kakao/KakaoUserInfo`, `/user/auth/oauth/kakao/KakaoUserInfoClient`, `/user/auth/oauth/kakao/config/KakaoConfig`, `user/controller/UserController`, `user/domain/User`, `user/dto/request/KakaoLoginRequest`, `user/dto/request/KakaoSignUpRequest`, `user/repository/UserRepository`, `user/service/UserService`
- `UserServiceTest`, `AuthControllerTest`, `UserControllerTest`, `TestSecurityConfig`

---

## 📌 참고 사항
- 관련 이슈(#22, #24)