### PR TITLE
feat: 웹소켓 연결 테스트를 위한 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ dependencies {
 
 	// H2
 	runtimeOnly 'com.h2database:h2'
+
+	// WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.java-websocket:Java-WebSocket:1.5.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/emotion_storage/chat/controller/StompChatController.java
+++ b/src/main/java/com/example/emotion_storage/chat/controller/StompChatController.java
@@ -1,0 +1,24 @@
+package com.example.emotion_storage.chat.controller;
+
+import com.example.emotion_storage.chat.dto.UserMessageDto;
+import com.example.emotion_storage.chat.service.ChatService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+@Tag(name = "StompChat", description = "웹소켓 STOMP 관련 API")
+public class StompChatController {
+
+    private final ChatService chatService;
+
+    @MessageMapping("/v1/test")
+    public void test(UserMessageDto userMessage) {
+        log.info("유저에게 메시지를 받았습니다.");
+        chatService.chatTest(userMessage);
+    }
+}

--- a/src/main/java/com/example/emotion_storage/chat/controller/WebSocketStompDocsController.java
+++ b/src/main/java/com/example/emotion_storage/chat/controller/WebSocketStompDocsController.java
@@ -1,5 +1,6 @@
 package com.example.emotion_storage.chat.controller;
 
+import com.example.emotion_storage.chat.dto.UserMessageDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,12 +15,18 @@ public class WebSocketStompDocsController {
     @Operation(
             summary = "STOMP WebSocket 사용법",
             description = """
-                          1. 연결: ws://호스트주소:8080/ws
-                          2. 메시지 전송(publish): /pub/v1/test(테스트용)
-                          3. 메시지 구독(subscribe): /sub/chatroom/{roomId}
-                          클라이언트는 위 경로를 사용해 STOMP 프로토콜로 연결, 송신, 수신을 수행합니다.
-                          """
+                  1. 연결: ws://호스트주소:8080/ws
+                  2. 메시지 전송(publish): /pub/v1/test (테스트용), 실제로는 /pub/v1/chat으로 설정해 둔 상태
+                  3. 메시지 구독(subscribe): /sub/chatroom/{roomId}
+                  클라이언트는 위 경로를 사용해 STOMP 프로토콜로 연결, 송신, 수신을 수행합니다.
+                  """
     )
     @GetMapping
-    public void doc() {}
+    public void doc(
+            @io.swagger.v3.oas.annotations.Parameter(
+                    description = "STOMP 메시지 예시 DTO",
+                    required = true
+            )
+            UserMessageDto userMessageDto
+    ) {}
 }

--- a/src/main/java/com/example/emotion_storage/chat/dto/UserMessageDto.java
+++ b/src/main/java/com/example/emotion_storage/chat/dto/UserMessageDto.java
@@ -1,0 +1,9 @@
+package com.example.emotion_storage.chat.dto;
+
+public record UserMessageDto(
+        String messageId,
+        String roomId,
+        String content,
+        String messageType,
+        String timestamp
+) {}

--- a/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
+++ b/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
@@ -1,0 +1,21 @@
+package com.example.emotion_storage.chat.service;
+
+import com.example.emotion_storage.chat.dto.UserMessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void chatTest(UserMessageDto userMessage) {
+        String message = "안녕하세요, 저는 MOOI입니다. 메시지를 보내주세요.";
+        messagingTemplate.convertAndSend("/sub/chatroom/" + userMessage.roomId(), message);
+    }
+}
+

--- a/src/main/java/com/example/emotion_storage/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/emotion_storage/global/config/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/session").authenticated()
                         .requestMatchers("/auth/**",
+                                "/ws/**",
                                 "/api/v1/users/login/**",
                                 "/api/v1/users/signup/**",
                                 "/docs/**",

--- a/src/main/java/com/example/emotion_storage/global/config/websocket/StompWebSocketConfig.java
+++ b/src/main/java/com/example/emotion_storage/global/config/websocket/StompWebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.example.emotion_storage.global.config.websocket;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@EnableWebSocketMessageBroker
+@Configuration
+@RequiredArgsConstructor
+public class StompWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*");
+        //.withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setApplicationDestinationPrefixes("/pub");
+        registry.enableSimpleBroker("/sub");
+    }
+}

--- a/src/main/java/com/example/emotion_storage/global/event/StompEventListener.java
+++ b/src/main/java/com/example/emotion_storage/global/event/StompEventListener.java
@@ -1,0 +1,29 @@
+package com.example.emotion_storage.global.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Slf4j
+@Component
+public class StompEventListener {
+
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectedEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccessor.getSessionId();
+
+        log.info("세션 {}이 STOMP 웹소켓에 연결되었습니다.", sessionId);
+    }
+
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccessor.getSessionId();
+
+        log.info("세션 {}이 STOMP 웹소켓 연결을 종료했습니다.", sessionId);
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
- 프론트엔드-백엔드 STOMP 웹소켓 테스트를 위한 기능 추가

---

## 📝 적용 범위
- 변경된 파일, 디렉터리, 모듈 등을 명시해주세요.

---

## 📌 참고 사항
- 사용 방법:
  -  WebSocket 연결: ws://<host>:8080/ws
  - 구독: /sub/chatroom/{roomId}
  - 발행: /pub/v1/test (본문: UserMessageDto JSON)