### PR TITLE
feat: 감정 대화 테스트를 위한 채팅방 반환 엔드포인트 추가

### DIFF
--- a/src/main/java/com/example/emotion_storage/chat/dto/response/ChatRoomCreateResponse.java
+++ b/src/main/java/com/example/emotion_storage/chat/dto/response/ChatRoomCreateResponse.java
@@ -1,0 +1,5 @@
+package com.example.emotion_storage.chat.dto.response;
+
+public record ChatRoomCreateResponse(
+        String roomId
+) {}

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -9,7 +9,9 @@ public enum SuccessMessage {
     LOGIN_SUCCESS("로그인 성공"),
     SIGNUP_SUCCESS("회원가입 성공"),
     ACCESS_TOKEN_REISSUE_SUCCESS("액세스 토큰 재발급 성공"),
-    SESSION_CHECK_SUCCESS("세션 확인 성공");
+    SESSION_CHECK_SUCCESS("세션 확인 성공"),
+
+    CHAT_ROOM_CREATE_SUCCESS("대화 시작 성공");
 
     private final String message;
 }

--- a/src/main/java/com/example/emotion_storage/home/controller/HomeController.java
+++ b/src/main/java/com/example/emotion_storage/home/controller/HomeController.java
@@ -1,0 +1,32 @@
+package com.example.emotion_storage.home.controller;
+
+import com.example.emotion_storage.chat.dto.response.ChatRoomCreateResponse;
+import com.example.emotion_storage.global.api.ApiResponse;
+import com.example.emotion_storage.global.api.SuccessMessage;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/home")
+@RequiredArgsConstructor
+@Tag(name = "Home", description = "홈 관련 API")
+public class HomeController {
+
+    @PostMapping("emotion-conversation/test")
+    @Operation(summary = "감정 대화 테스트를 위한 채팅방 반환 API", description = "감정 대화 테스트를 위한 채팅방 ID를 생성하고 반환합니다.")
+    public ResponseEntity<ApiResponse<ChatRoomCreateResponse>> createTest() {
+        ChatRoomCreateResponse response = new ChatRoomCreateResponse(UUID.randomUUID().toString());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(SuccessMessage.CHAT_ROOM_CREATE_SUCCESS.getMessage(), response));
+    }
+}
+


### PR DESCRIPTION
## ✨ 작업 내용
- FE-BE 웹소켓 테스트를 진행할 때 채팅방 id(랜덤)를 반환하는 기능 추가

---

## 📝 적용 범위
- 변경된 파일, 디렉터리, 모듈 등을 명시해주세요.

---

## 📌 참고 사항
- 관련 이슈 번호, 리뷰 시 유의사항 등을 적어주세요.