### PR TITLE
refactor: 채팅방 아이디 생성을 위해 테스트 유저를 사용할 수 있도록 변경

### DIFF
--- a/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
+++ b/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
@@ -38,8 +38,8 @@ public class ChatService {
     }
 
     @Transactional
-    public ApiResponse<ChatRoomCreateResponse> createTestChatRoom() {
-        User user = userRepository.findById(1L)
+    public ApiResponse<ChatRoomCreateResponse> createTestChatRoom(Long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
 
         ChatRoom chatRoom = ChatRoom.builder()

--- a/src/main/java/com/example/emotion_storage/home/controller/HomeController.java
+++ b/src/main/java/com/example/emotion_storage/home/controller/HomeController.java
@@ -38,8 +38,11 @@ public class HomeController {
 
     @PostMapping("emotion-conversation/test")
     @Operation(summary = "감정 대화 테스트를 위한 채팅방 반환 API", description = "감정 대화 테스트를 위한 채팅방 ID를 생성하고 반환합니다.")
-    public ResponseEntity<ApiResponse<ChatRoomCreateResponse>> createChatRoomForTest() {
-        ApiResponse<ChatRoomCreateResponse> response = chatService.createTestChatRoom();
+    public ResponseEntity<ApiResponse<ChatRoomCreateResponse>> createChatRoomForTest(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        ApiResponse<ChatRoomCreateResponse> response = chatService.createTestChatRoom(userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 


### PR DESCRIPTION
## ✨ 작업 내용
- 채팅방 아이디 발급시 CustomUserPrincipal이 null일 때는 테스트 유저를 사용하도록 변경

---

## 📝 적용 범위
- 변경된 파일, 디렉터리, 모듈 등을 명시해주세요.

---

## 📌 참고 사항
- 관련 이슈 번호, 리뷰 시 유의사항 등을 적어주세요.