### PR TITLE
feat: 타임캡슐 API 구현

### DIFF
--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -24,7 +24,8 @@ public enum SuccessMessage {
 
     // Time Capsule
     GET_MONTHLY_TIME_CAPSULE_DATES_SUCCESS("월별 타임캡슐 날짜 목록 조회 성공"),
-    GET_TIME_CAPSULE_LIST_SUCCESS("타임캡슐 목록 조회 성공");
+    GET_TIME_CAPSULE_LIST_SUCCESS("타임캡슐 목록 조회 성공"),
+    GET_FAVORITE_TIME_CAPSULE_LIST_SUCCESS("즐겨찾기 타임캡슐 목록 조회 성공");
 
     private final String message;
 }

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -27,7 +27,8 @@ public enum SuccessMessage {
     GET_TIME_CAPSULE_LIST_SUCCESS("타임캡슐 목록 조회 성공"),
     GET_FAVORITE_TIME_CAPSULE_LIST_SUCCESS("즐겨찾기 타임캡슐 목록 조회 성공"),
     ADD_FAVORITE_TIME_CAPSULE_SUCCESS("타임캡슐 즐겨찾기 추가 성공"),
-    REMOVE_FAVORITE_TIME_CAPSULE_SUCCESS("타임캡슐 즐겨찾기 해제 성공");
+    REMOVE_FAVORITE_TIME_CAPSULE_SUCCESS("타임캡슐 즐겨찾기 해제 성공"),
+    OPEN_TIME_CAPSULE_SUCCESS("타임캡슐 열람 성공");
 
     private final String message;
 }

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -28,7 +28,9 @@ public enum SuccessMessage {
     GET_FAVORITE_TIME_CAPSULE_LIST_SUCCESS("즐겨찾기 타임캡슐 목록 조회 성공"),
     ADD_FAVORITE_TIME_CAPSULE_SUCCESS("타임캡슐 즐겨찾기 추가 성공"),
     REMOVE_FAVORITE_TIME_CAPSULE_SUCCESS("타임캡슐 즐겨찾기 해제 성공"),
-    OPEN_TIME_CAPSULE_SUCCESS("타임캡슐 열람 성공");
+    OPEN_TIME_CAPSULE_SUCCESS("타임캡슐 열람 성공"),
+    UPDATE_TIME_CAPSULE_MIND_NOTE_SUCCESS("타임캡슐 내 마음 노트 수정 성공"),
+    ;
 
     private final String message;
 }

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -30,6 +30,7 @@ public enum SuccessMessage {
     REMOVE_FAVORITE_TIME_CAPSULE_SUCCESS("타임캡슐 즐겨찾기 해제 성공"),
     OPEN_TIME_CAPSULE_SUCCESS("타임캡슐 열람 성공"),
     UPDATE_TIME_CAPSULE_MIND_NOTE_SUCCESS("타임캡슐 내 마음 노트 수정 성공"),
+    DELETE_TIME_CAPSULE_SUCCESS("타임캡슐 삭제 성공"),
     ;
 
     private final String message;

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -20,7 +20,9 @@ public enum SuccessMessage {
     GET_NEW_TIME_CAPSULE_SUCCESS("도착한 타임캡슐 여부 조회 성공"),
     GET_NEW_DAILY_REPORT_SUCCESS("새로운 일일리포트 여부 조회 성공"),
     GET_NEW_NOTIFICATION_SUCCESS("신규 알림 여부 조회 성공"),
-    GET_HOME_INFO_SUCCESS("홈 화면 정보 API 조회 성공");
+    GET_HOME_INFO_SUCCESS("홈 화면 정보 API 조회 성공"),
+
+    GET_MONTHLY_TIME_CAPSULE_DATES_SUCCESS("월별 타임캡슐 날짜 목록 조회 성공");
 
     private final String message;
 }

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -28,6 +28,7 @@ public enum SuccessMessage {
     GET_FAVORITE_TIME_CAPSULE_LIST_SUCCESS("즐겨찾기 타임캡슐 목록 조회 성공"),
     ADD_FAVORITE_TIME_CAPSULE_SUCCESS("타임캡슐 즐겨찾기 추가 성공"),
     REMOVE_FAVORITE_TIME_CAPSULE_SUCCESS("타임캡슐 즐겨찾기 해제 성공"),
+    GET_TIME_CAPSULE_DETAIL_SUCCESS("타임캡슐 상세 조회 성공"),
     OPEN_TIME_CAPSULE_SUCCESS("타임캡슐 열람 성공"),
     UPDATE_TIME_CAPSULE_MIND_NOTE_SUCCESS("타임캡슐 내 마음 노트 수정 성공"),
     DELETE_TIME_CAPSULE_SUCCESS("타임캡슐 삭제 성공"),

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -22,7 +22,9 @@ public enum SuccessMessage {
     GET_NEW_NOTIFICATION_SUCCESS("신규 알림 여부 조회 성공"),
     GET_HOME_INFO_SUCCESS("홈 화면 정보 API 조회 성공"),
 
-    GET_MONTHLY_TIME_CAPSULE_DATES_SUCCESS("월별 타임캡슐 날짜 목록 조회 성공");
+    // Time Capsule
+    GET_MONTHLY_TIME_CAPSULE_DATES_SUCCESS("월별 타임캡슐 날짜 목록 조회 성공"),
+    GET_TIME_CAPSULE_LIST_SUCCESS("타임캡슐 목록 조회 성공");
 
     private final String message;
 }

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -25,7 +25,9 @@ public enum SuccessMessage {
     // Time Capsule
     GET_MONTHLY_TIME_CAPSULE_DATES_SUCCESS("월별 타임캡슐 날짜 목록 조회 성공"),
     GET_TIME_CAPSULE_LIST_SUCCESS("타임캡슐 목록 조회 성공"),
-    GET_FAVORITE_TIME_CAPSULE_LIST_SUCCESS("즐겨찾기 타임캡슐 목록 조회 성공");
+    GET_FAVORITE_TIME_CAPSULE_LIST_SUCCESS("즐겨찾기 타임캡슐 목록 조회 성공"),
+    ADD_FAVORITE_TIME_CAPSULE_SUCCESS("타임캡슐 즐겨찾기 추가 성공"),
+    REMOVE_FAVORITE_TIME_CAPSULE_SUCCESS("타임캡슐 즐겨찾기 해제 성공");
 
     private final String message;
 }

--- a/src/main/java/com/example/emotion_storage/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/emotion_storage/global/exception/ErrorCode.java
@@ -23,6 +23,10 @@ public enum ErrorCode {
 
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
     CHAT_ROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, "채팅방에 접근할 수 없습니다."),
+
+    TIME_CAPSULE_NOT_FOUND(HttpStatus.NOT_FOUND, "타임캡슐을 찾을 수 없습니다."),
+    TIME_CAPSULE_IS_NOT_OWNED(HttpStatus.FORBIDDEN, "사용자의 타임캡슐이 아닙니다."),
+    TIME_CAPSULE_FAVORITE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "즐겨찾기는 최대 30개까지만 가능합니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/emotion_storage/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/emotion_storage/global/exception/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
 
     TIME_CAPSULE_NOT_FOUND(HttpStatus.NOT_FOUND, "타임캡슐을 찾을 수 없습니다."),
     TIME_CAPSULE_IS_NOT_OWNED(HttpStatus.FORBIDDEN, "사용자의 타임캡슐이 아닙니다."),
-    TIME_CAPSULE_FAVORITE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "즐겨찾기는 최대 30개까지만 가능합니다.")
+    TIME_CAPSULE_FAVORITE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "즐겨찾기는 최대 30개까지만 가능합니다."),
+    TIME_CAPSULE_KEY_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "열쇠가 부족하여 타임캡슐을 열 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
@@ -1,7 +1,6 @@
 package com.example.emotion_storage.timecapsule.controller;
 
 import com.example.emotion_storage.global.api.ApiResponse;
-import com.example.emotion_storage.global.api.SuccessMessage;
 import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
 import com.example.emotion_storage.timecapsule.dto.request.TimeCapsuleFavoriteRequest;
 import com.example.emotion_storage.timecapsule.dto.request.TimeCapsuleNoteUpdateRequest;

--- a/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
@@ -3,9 +3,11 @@ package com.example.emotion_storage.timecapsule.controller;
 import com.example.emotion_storage.global.api.ApiResponse;
 import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleExistDateResponse;
+import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleListResponse;
 import com.example.emotion_storage.timecapsule.service.TimeCapsuleService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +34,20 @@ public class TimeCapsuleController {
         Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
         log.info("사용자 {}의 {}년 {}월의 타임캡슐 목록 조회를 요청받았습니다.", userId, year, month);
         ApiResponse<TimeCapsuleExistDateResponse> response = timeCapsuleService.getMonthlyActiveDates(year, month, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    @Operation()
+    public ResponseEntity<ApiResponse<TimeCapsuleListResponse>> getTimeCapsuleList(
+            @RequestParam LocalDate startDate, @RequestParam LocalDate endDate,
+            @RequestParam int page, @RequestParam int limit, @RequestParam(defaultValue = "all") String status,
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}의 타임캡슐 목록 조회를 요청받았습니다.", userId);
+        ApiResponse<TimeCapsuleListResponse> response =
+                timeCapsuleService.getTimeCapsuleList(startDate, endDate, page, limit, status, userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -104,6 +105,18 @@ public class TimeCapsuleController {
         Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
         log.info("사용자 {}가 타임캡슐 {}의 마음노트 수정을 요청했습니다.", userId, timeCapsuleId);
         ApiResponse<Void> response = timeCapsuleService.updateTimeCapsuleNote(timeCapsuleId, request, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("{capsuleId}")
+    @Operation(summary = "타임캡슐 삭제", description = "타임캡슐을 삭제합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteTimeCapsule(
+            @PathVariable("capsuleId") Long timeCapsuleId,
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}가 타임캡슐 {} 삭제를 요청했습니다.", userId, timeCapsuleId);
+        ApiResponse<Void> response = timeCapsuleService.deleteTimeCapsule(timeCapsuleId, userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
@@ -1,0 +1,37 @@
+package com.example.emotion_storage.timecapsule.controller;
+
+import com.example.emotion_storage.global.api.ApiResponse;
+import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
+import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleExistDateResponse;
+import com.example.emotion_storage.timecapsule.service.TimeCapsuleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/time-capsule")
+@RequiredArgsConstructor
+@Tag(name = "TimeCapsule", description = "타임캡슐 관련 API")
+public class TimeCapsuleController {
+
+    private final TimeCapsuleService timeCapsuleService;
+
+    @GetMapping("/date")
+    @Operation(summary = "타임캡슐 존재하는 날짜 조회", description = "yyyy년 MM월의 날짜 중 캡슐이 존재하는 날짜 목록을 반환합니다.")
+    public ResponseEntity<ApiResponse<TimeCapsuleExistDateResponse>> getMonthlyActiveDates(
+            @RequestParam int year, @RequestParam int month, @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}의 {}년 {}월의 타임캡슐 목록 조회를 요청받았습니다.", userId, year, month);
+        ApiResponse<TimeCapsuleExistDateResponse> response = timeCapsuleService.getMonthlyActiveDates(year, month, userId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
@@ -2,7 +2,9 @@ package com.example.emotion_storage.timecapsule.controller;
 
 import com.example.emotion_storage.global.api.ApiResponse;
 import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
+import com.example.emotion_storage.timecapsule.dto.request.TimeCapsuleFavoriteRequest;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleExistDateResponse;
+import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleFavoriteResponse;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleListResponse;
 import com.example.emotion_storage.timecapsule.service.TimeCapsuleService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +15,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -60,6 +66,19 @@ public class TimeCapsuleController {
         log.info("사용자 {}의 즐겨찾기 타임캡슐 목록 조회를 요청받았습니다.", userId);
         ApiResponse<TimeCapsuleListResponse> response =
                 timeCapsuleService.getFavoriteTimeCapsules(page, limit, sort, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("{capsuleId}/favorite")
+    @Operation()
+    public ResponseEntity<ApiResponse<TimeCapsuleFavoriteResponse>> setFavorite(
+            @PathVariable("capsuleId") Long timeCapsuleId,
+            @RequestBody TimeCapsuleFavoriteRequest request,
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}가 타임캡슐 {} 즐겨찾기 변경을 요청했습니다.", userId, timeCapsuleId);
+        ApiResponse<TimeCapsuleFavoriteResponse> response = timeCapsuleService.setFavorite(timeCapsuleId, request, userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
@@ -1,6 +1,7 @@
 package com.example.emotion_storage.timecapsule.controller;
 
 import com.example.emotion_storage.global.api.ApiResponse;
+import com.example.emotion_storage.global.api.SuccessMessage;
 import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
 import com.example.emotion_storage.timecapsule.dto.request.TimeCapsuleFavoriteRequest;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleExistDateResponse;
@@ -17,7 +18,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -70,7 +70,7 @@ public class TimeCapsuleController {
     }
 
     @PatchMapping("{capsuleId}/favorite")
-    @Operation()
+    @Operation(summary = "즐겨찾기 추가 및 해제", description = "타임캡슐을 즐겨찾기 등록하거나 해제합니다.")
     public ResponseEntity<ApiResponse<TimeCapsuleFavoriteResponse>> setFavorite(
             @PathVariable("capsuleId") Long timeCapsuleId,
             @RequestBody TimeCapsuleFavoriteRequest request,
@@ -79,6 +79,17 @@ public class TimeCapsuleController {
         Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
         log.info("사용자 {}가 타임캡슐 {} 즐겨찾기 변경을 요청했습니다.", userId, timeCapsuleId);
         ApiResponse<TimeCapsuleFavoriteResponse> response = timeCapsuleService.setFavorite(timeCapsuleId, request, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("{capsuleId}/open")
+    @Operation(summary = "타임캡슐 열람", description = "타임캡슐을 열람 상태로 변경합니다.")
+    public ResponseEntity<ApiResponse<Void>> openTimeCapsule(
+            @PathVariable("capsuleId") Long timeCapsuleId, @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}가 타임캡슐 {} 열람을 요청했습니다.", userId, timeCapsuleId);
+        ApiResponse<Void> response = timeCapsuleService.openTimeCapsule(timeCapsuleId, userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
@@ -5,6 +5,7 @@ import com.example.emotion_storage.global.api.SuccessMessage;
 import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
 import com.example.emotion_storage.timecapsule.dto.request.TimeCapsuleFavoriteRequest;
 import com.example.emotion_storage.timecapsule.dto.request.TimeCapsuleNoteUpdateRequest;
+import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleDetailResponse;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleExistDateResponse;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleFavoriteResponse;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleListResponse;
@@ -92,6 +93,18 @@ public class TimeCapsuleController {
         Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
         log.info("사용자 {}가 타임캡슐 {} 열람을 요청했습니다.", userId, timeCapsuleId);
         ApiResponse<Void> response = timeCapsuleService.openTimeCapsule(timeCapsuleId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("{capsuleId}")
+    @Operation(summary = "타임캡슐 상세 조회", description = "타임캡슐의 상세 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<TimeCapsuleDetailResponse>> getTimeCapsuleDetail(
+            @PathVariable("capsuleId") Long timeCapsuleId,
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}가 타임캡슐 {}의 상세 조회를 요청했습니다.", userId, timeCapsuleId);
+        ApiResponse<TimeCapsuleDetailResponse> response = timeCapsuleService.getTimeCapsuleDetail(timeCapsuleId, userId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
@@ -38,7 +38,7 @@ public class TimeCapsuleController {
     }
 
     @GetMapping
-    @Operation()
+    @Operation(summary = "타임캡슐 목록 조회", description = "날짜 및 타임캡슐 상태를 기준으로 타임캡슐 목록을 조회하고 반환합니다.")
     public ResponseEntity<ApiResponse<TimeCapsuleListResponse>> getTimeCapsuleList(
             @RequestParam LocalDate startDate, @RequestParam LocalDate endDate,
             @RequestParam int page, @RequestParam int limit, @RequestParam(defaultValue = "all") String status,
@@ -48,6 +48,18 @@ public class TimeCapsuleController {
         log.info("사용자 {}의 타임캡슐 목록 조회를 요청받았습니다.", userId);
         ApiResponse<TimeCapsuleListResponse> response =
                 timeCapsuleService.getTimeCapsuleList(startDate, endDate, page, limit, status, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/favorites")
+    @Operation(summary = "즐겨찾기 타임캡슐 목록 조회", description = "즐겨찾기한 타임캡슐을 최신순 또는 즐겨찾기한 순으로 조회합니다.")
+    public ResponseEntity<ApiResponse<TimeCapsuleListResponse>> getFavoriteTimeCapsules(
+            @RequestParam int page, @RequestParam int limit, @RequestParam String sort, @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}의 즐겨찾기 타임캡슐 목록 조회를 요청받았습니다.", userId);
+        ApiResponse<TimeCapsuleListResponse> response =
+                timeCapsuleService.getFavoriteTimeCapsules(page, limit, sort, userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/controller/TimeCapsuleController.java
@@ -4,6 +4,7 @@ import com.example.emotion_storage.global.api.ApiResponse;
 import com.example.emotion_storage.global.api.SuccessMessage;
 import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
 import com.example.emotion_storage.timecapsule.dto.request.TimeCapsuleFavoriteRequest;
+import com.example.emotion_storage.timecapsule.dto.request.TimeCapsuleNoteUpdateRequest;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleExistDateResponse;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleFavoriteResponse;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleListResponse;
@@ -90,6 +91,19 @@ public class TimeCapsuleController {
         Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
         log.info("사용자 {}가 타임캡슐 {} 열람을 요청했습니다.", userId, timeCapsuleId);
         ApiResponse<Void> response = timeCapsuleService.openTimeCapsule(timeCapsuleId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("{capsuleId}/note")
+    @Operation(summary = "타임캡슐 마음노트 수정", description = "타임캡슐 마음노트를 수정합니다.")
+    public ResponseEntity<ApiResponse<Void>> updateTimeCapsuleNote(
+            @PathVariable("capsuleId") Long timeCapsuleId,
+            @RequestBody TimeCapsuleNoteUpdateRequest request,
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}가 타임캡슐 {}의 마음노트 수정을 요청했습니다.", userId, timeCapsuleId);
+        ApiResponse<Void> response = timeCapsuleService.updateTimeCapsuleNote(timeCapsuleId, request, userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/domain/AnalyzedEmotion.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/domain/AnalyzedEmotion.java
@@ -24,6 +24,9 @@ public class AnalyzedEmotion extends BaseTimeEntity {
     @Column(name = "analyzed_emotion", columnDefinition = "TEXT", nullable = false)
     private String analyzedEmotion;
 
+    @Column(name = "percentage", nullable = false)
+    private int percentage;
+
     public void setTimeCapsule(TimeCapsule timeCapsule) {
         this.timeCapsule = timeCapsule;
     }

--- a/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
@@ -46,6 +46,8 @@ public class TimeCapsule extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String myMindNote;
 
+    private LocalDateTime favoriteAt;
+
     private LocalDateTime openedAt;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
@@ -94,7 +94,12 @@ public class TimeCapsule extends BaseTimeEntity {
     public void setIsFavorite(Boolean isFavorite) {
         this.isFavorite = isFavorite;
     }
+
     public void setIsOpened(Boolean isOpened) {
         this.isOpened = true;
+    }
+
+    public void updateMyMindNote(String myMindNote) {
+        this.myMindNote = myMindNote;
     }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
@@ -94,4 +94,7 @@ public class TimeCapsule extends BaseTimeEntity {
     public void setIsFavorite(Boolean isFavorite) {
         this.isFavorite = isFavorite;
     }
+    public void setIsOpened(Boolean isOpened) {
+        this.isOpened = true;
+    }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
@@ -96,7 +96,7 @@ public class TimeCapsule extends BaseTimeEntity {
     }
 
     public void setIsOpened(Boolean isOpened) {
-        this.isOpened = true;
+        this.isOpened = isOpened;
     }
 
     public void updateMyMindNote(String myMindNote) {

--- a/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
@@ -86,4 +86,12 @@ public class TimeCapsule extends BaseTimeEntity {
     public void setReport(Report report) {
         this.report = report;
     }
+
+    public void setFavoriteAt(LocalDateTime favoriteAt) {
+        this.favoriteAt = favoriteAt;
+    }
+
+    public void setIsFavorite(Boolean isFavorite) {
+        this.isFavorite = isFavorite;
+    }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
@@ -43,7 +43,7 @@ public class TimeCapsule extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String dialogueSummary;
 
-    @Column(columnDefinition = "TEXT", nullable = false)
+    @Column(columnDefinition = "TEXT")
     private String myMindNote;
 
     private LocalDateTime favoriteAt;

--- a/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsule.java
@@ -102,4 +102,8 @@ public class TimeCapsule extends BaseTimeEntity {
     public void updateMyMindNote(String myMindNote) {
         this.myMindNote = myMindNote;
     }
+
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsuleOpenCost.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsuleOpenCost.java
@@ -1,0 +1,27 @@
+package com.example.emotion_storage.timecapsule.domain;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TimeCapsuleOpenCost {
+    ONE_KEY(1, 7, 1),
+    THREE_KEYS(8, 30, 3),
+    SEVEN_KEYS(31, 90, 7),
+    ELEVEN_KEYS(91, 180, 11),
+    FIFTEEN_KEYS(181, Integer.MAX_VALUE, 15);
+
+    private final int minDays;
+    private final int maxDays;
+    private final int requiredKeys;
+
+    public static int getRequiredKeys(long days) {
+        return Arrays.stream(TimeCapsuleOpenCost.values())
+                .filter(policy -> policy.minDays <= days && days <= policy.maxDays)
+                .findFirst()
+                .map(TimeCapsuleOpenCost::getRequiredKeys)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 날짜입니다."));
+    }
+}

--- a/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsuleStatus.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/domain/TimeCapsuleStatus.java
@@ -1,0 +1,33 @@
+package com.example.emotion_storage.timecapsule.domain;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TimeCapsuleStatus {
+    TEMP_SAVED("임시 저장"), LOCKED("잠김"), ARRIVED("도착"), OPENED("열림");
+
+    private final String statusMessage;
+
+    public static TimeCapsuleStatus getStatus(TimeCapsule timeCapsule) {
+        // 임시 저장
+        if (timeCapsule.getIsTempSave()) {
+            return TEMP_SAVED;
+        }
+        // 열림
+        if (timeCapsule.getIsOpened()) {
+            return OPENED;
+        }
+
+        LocalDateTime openAt = timeCapsule.getOpenedAt();
+        LocalDateTime now = LocalDateTime.now();
+        // 잠김
+        if (now.isBefore(openAt)) {
+            return LOCKED;
+        }
+        // 도착
+        return ARRIVED;
+    }
+}

--- a/src/main/java/com/example/emotion_storage/timecapsule/dto/EmotionDetailDto.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/dto/EmotionDetailDto.java
@@ -1,0 +1,6 @@
+package com.example.emotion_storage.timecapsule.dto;
+
+public record EmotionDetailDto(
+        String label,
+        int ratio
+) {}

--- a/src/main/java/com/example/emotion_storage/timecapsule/dto/PaginationDto.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/dto/PaginationDto.java
@@ -1,0 +1,7 @@
+package com.example.emotion_storage.timecapsule.dto;
+
+public record PaginationDto(
+        int page,
+        int limit,
+        int totalPage
+) {}

--- a/src/main/java/com/example/emotion_storage/timecapsule/dto/TimeCapsuleDto.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/dto/TimeCapsuleDto.java
@@ -2,21 +2,27 @@ package com.example.emotion_storage.timecapsule.dto;
 
 import com.example.emotion_storage.timecapsule.domain.AnalyzedEmotion;
 import com.example.emotion_storage.timecapsule.domain.TimeCapsule;
+import com.example.emotion_storage.timecapsule.domain.TimeCapsuleStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record TimeCapsuleDto(
         Long id,
+        LocalDateTime historyDate,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         LocalDateTime openAt,
         Boolean isFavorite,
         List<String> emotions,
-        String title
+        String title,
+        String timeCapsuleStatus
 ) {
     public static TimeCapsuleDto of(TimeCapsule entity) {
+        TimeCapsuleStatus status = TimeCapsuleStatus.getStatus(entity);
+
         return new TimeCapsuleDto(
                 entity.getId(),
+                entity.getHistoryDate(),
                 entity.getCreatedAt(),
                 entity.getUpdatedAt(),
                 entity.getOpenedAt(),
@@ -25,7 +31,8 @@ public record TimeCapsuleDto(
                         .stream()
                         .map(AnalyzedEmotion::getAnalyzedEmotion)
                         .toList(),
-                entity.getOneLineSummary()
+                entity.getOneLineSummary(),
+                status.getStatusMessage()
         );
     }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/dto/TimeCapsuleDto.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/dto/TimeCapsuleDto.java
@@ -1,0 +1,31 @@
+package com.example.emotion_storage.timecapsule.dto;
+
+import com.example.emotion_storage.timecapsule.domain.AnalyzedEmotion;
+import com.example.emotion_storage.timecapsule.domain.TimeCapsule;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TimeCapsuleDto(
+        Long id,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime openAt,
+        Boolean isFavorite,
+        List<String> emotions,
+        String title
+) {
+    public static TimeCapsuleDto of(TimeCapsule entity) {
+        return new TimeCapsuleDto(
+                entity.getId(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt(),
+                entity.getOpenedAt(),
+                entity.getIsFavorite(),
+                entity.getAnalyzedEmotions()
+                        .stream()
+                        .map(AnalyzedEmotion::getAnalyzedEmotion)
+                        .toList(),
+                entity.getOneLineSummary()
+        );
+    }
+}

--- a/src/main/java/com/example/emotion_storage/timecapsule/dto/TimeCapsuleDto.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/dto/TimeCapsuleDto.java
@@ -15,10 +15,10 @@ public record TimeCapsuleDto(
         Boolean isFavorite,
         List<String> emotions,
         String title,
-        String timeCapsuleStatus
+        String status
 ) {
-    public static TimeCapsuleDto of(TimeCapsule entity) {
-        TimeCapsuleStatus status = TimeCapsuleStatus.getStatus(entity);
+    public static TimeCapsuleDto from(TimeCapsule entity) {
+        TimeCapsuleStatus timeCapsuleStatus = TimeCapsuleStatus.getStatus(entity);
 
         return new TimeCapsuleDto(
                 entity.getId(),
@@ -32,7 +32,7 @@ public record TimeCapsuleDto(
                         .map(AnalyzedEmotion::getAnalyzedEmotion)
                         .toList(),
                 entity.getOneLineSummary(),
-                status.getStatusMessage()
+                timeCapsuleStatus.getStatusMessage()
         );
     }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/dto/request/TimeCapsuleFavoriteRequest.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/dto/request/TimeCapsuleFavoriteRequest.java
@@ -1,0 +1,6 @@
+package com.example.emotion_storage.timecapsule.dto.request;
+
+public record TimeCapsuleFavoriteRequest(
+        boolean addFavorite
+) {
+}

--- a/src/main/java/com/example/emotion_storage/timecapsule/dto/request/TimeCapsuleNoteUpdateRequest.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/dto/request/TimeCapsuleNoteUpdateRequest.java
@@ -1,0 +1,5 @@
+package com.example.emotion_storage.timecapsule.dto.request;
+
+public record TimeCapsuleNoteUpdateRequest(
+        String content
+) {}

--- a/src/main/java/com/example/emotion_storage/timecapsule/dto/response/TimeCapsuleDetailResponse.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/dto/response/TimeCapsuleDetailResponse.java
@@ -1,0 +1,48 @@
+package com.example.emotion_storage.timecapsule.dto.response;
+
+import com.example.emotion_storage.timecapsule.domain.AnalyzedFeedback;
+import com.example.emotion_storage.timecapsule.domain.TimeCapsule;
+import com.example.emotion_storage.timecapsule.domain.TimeCapsuleStatus;
+import com.example.emotion_storage.timecapsule.dto.EmotionDetailDto;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TimeCapsuleDetailResponse(
+        Long id,
+        LocalDateTime historyDate,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        String status,
+        LocalDateTime openAt,
+        Boolean isFavorite,
+        String title,
+        String summary,
+        List<EmotionDetailDto> emotionDetails,
+        List<String> comments,
+        String note
+) {
+    public static TimeCapsuleDetailResponse from(TimeCapsule entity) {
+        TimeCapsuleStatus timeCapsuleStatus = TimeCapsuleStatus.getStatus(entity);
+
+        return new TimeCapsuleDetailResponse(
+                entity.getId(),
+                entity.getHistoryDate(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt(),
+                timeCapsuleStatus.getStatusMessage(),
+                entity.getOpenedAt(),
+                entity.getIsFavorite(),
+                entity.getOneLineSummary(),
+                entity.getDialogueSummary(),
+                entity.getAnalyzedEmotions()
+                        .stream()
+                        .map(emotions -> new EmotionDetailDto(emotions.getAnalyzedEmotion(), emotions.getPercentage()))
+                        .toList(),
+                entity.getAnalyzedFeedbacks()
+                        .stream()
+                        .map(AnalyzedFeedback::getAnalyzedFeedback)
+                        .toList(),
+                entity.getMyMindNote()
+        );
+    }
+}

--- a/src/main/java/com/example/emotion_storage/timecapsule/dto/response/TimeCapsuleExistDateResponse.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/dto/response/TimeCapsuleExistDateResponse.java
@@ -1,0 +1,9 @@
+package com.example.emotion_storage.timecapsule.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record TimeCapsuleExistDateResponse(
+        int totalDates,
+        List<LocalDate> dates
+) {}

--- a/src/main/java/com/example/emotion_storage/timecapsule/dto/response/TimeCapsuleFavoriteResponse.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/dto/response/TimeCapsuleFavoriteResponse.java
@@ -1,0 +1,9 @@
+package com.example.emotion_storage.timecapsule.dto.response;
+
+import java.time.LocalDateTime;
+
+public record TimeCapsuleFavoriteResponse(
+        boolean isFavorite,
+        LocalDateTime favoriteAt,
+        int favoritesCnt
+) {}

--- a/src/main/java/com/example/emotion_storage/timecapsule/dto/response/TimeCapsuleListResponse.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/dto/response/TimeCapsuleListResponse.java
@@ -1,0 +1,11 @@
+package com.example.emotion_storage.timecapsule.dto.response;
+
+import com.example.emotion_storage.timecapsule.dto.PaginationDto;
+import com.example.emotion_storage.timecapsule.dto.TimeCapsuleDto;
+import java.util.List;
+
+public record TimeCapsuleListResponse(
+        PaginationDto pagination,
+        int totalCapsules,
+        List<TimeCapsuleDto> timeCapsules
+) {}

--- a/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
@@ -39,4 +39,6 @@ public interface TimeCapsuleRepository extends JpaRepository<TimeCapsule, Long> 
 
     // 즐겨찾기한 타임캡슐 목록
     Page<TimeCapsule> findByUser_IdAndDeletedAtIsNullAndIsFavoriteIsTrue(Long userId, Pageable pageable);
+
+    int countByUser_IdAndIsFavoriteTrue(Long userId);
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
@@ -1,6 +1,8 @@
 package com.example.emotion_storage.timecapsule.repository;
 
 import com.example.emotion_storage.timecapsule.domain.TimeCapsule;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +18,9 @@ public interface TimeCapsuleRepository extends JpaRepository<TimeCapsule, Long> 
     
     @Query("SELECT COUNT(tc) FROM TimeCapsule tc WHERE tc.user.id = :userId AND tc.isOpened = false AND tc.deletedAt IS NULL")
     Long countUnopenedTimeCapsulesByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT DISTINCT CAST(tc.createdAt AS DATE) from TimeCapsule tc "
+            + "WHERE tc.user.id = :userId AND tc.createdAt >= :start AND tc.createdAt < :end "
+            + "ORDER BY CAST(tc.createdAt AS DATE)")
+    List<LocalDate> findActiveDatesInRange(@Param("userId") Long userId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
@@ -1,8 +1,10 @@
 package com.example.emotion_storage.timecapsule.repository;
 
 import com.example.emotion_storage.timecapsule.domain.TimeCapsule;
-import java.time.LocalDate;
+import java.sql.Date;
 import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,7 +22,15 @@ public interface TimeCapsuleRepository extends JpaRepository<TimeCapsule, Long> 
     Long countUnopenedTimeCapsulesByUserId(@Param("userId") Long userId);
 
     @Query("SELECT DISTINCT CAST(tc.historyDate AS DATE) from TimeCapsule tc "
-            + "WHERE tc.user.id = :userId AND tc.historyDate >= :start AND tc.historyDate < :end "
+            + "WHERE tc.user.id = :userId AND tc.historyDate >= :start AND tc.historyDate < :end AND tc.deletedAt IS NULL "
             + "ORDER BY CAST(tc.historyDate AS DATE)")
-    List<LocalDate> findActiveDatesInRange(@Param("userId") Long userId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+    List<Date> findActiveDatesInRange(@Param("userId") Long userId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    Page<TimeCapsule> findByUser_IdAndDeletedAtIsNullAndOpenedAtGreaterThanEqualAndOpenedAtLessThanEqual(
+            Long userId, LocalDateTime start, LocalDateTime end, Pageable pageable
+    );
+
+    Page<TimeCapsule> findByUser_IdAndDeletedAtIsNullAndHistoryDateBetween(
+            Long userId, LocalDateTime start, LocalDateTime end, Pageable pageable
+    );
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -26,11 +27,16 @@ public interface TimeCapsuleRepository extends JpaRepository<TimeCapsule, Long> 
             + "ORDER BY CAST(tc.historyDate AS DATE)")
     List<Date> findActiveDatesInRange(@Param("userId") Long userId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
-    Page<TimeCapsule> findByUser_IdAndDeletedAtIsNullAndOpenedAtGreaterThanEqualAndOpenedAtLessThanEqual(
+    // 전체 타임캡슐 목록
+    Page<TimeCapsule> findByUser_IdAndDeletedAtIsNullAndIsOpenedFalseAndOpenedAtGreaterThanEqualAndOpenedAtLessThanEqual(
             Long userId, LocalDateTime start, LocalDateTime end, Pageable pageable
     );
 
+    // 도착한 타임캡슐 목록
     Page<TimeCapsule> findByUser_IdAndDeletedAtIsNullAndHistoryDateBetween(
             Long userId, LocalDateTime start, LocalDateTime end, Pageable pageable
     );
+
+    // 즐겨찾기한 타임캡슐 목록
+    Page<TimeCapsule> findByUser_IdAndDeletedAtIsNullAndIsFavoriteIsTrue(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
@@ -19,8 +19,8 @@ public interface TimeCapsuleRepository extends JpaRepository<TimeCapsule, Long> 
     @Query("SELECT COUNT(tc) FROM TimeCapsule tc WHERE tc.user.id = :userId AND tc.isOpened = false AND tc.deletedAt IS NULL")
     Long countUnopenedTimeCapsulesByUserId(@Param("userId") Long userId);
 
-    @Query("SELECT DISTINCT CAST(tc.createdAt AS DATE) from TimeCapsule tc "
-            + "WHERE tc.user.id = :userId AND tc.createdAt >= :start AND tc.createdAt < :end "
-            + "ORDER BY CAST(tc.createdAt AS DATE)")
+    @Query("SELECT DISTINCT CAST(tc.historyDate AS DATE) from TimeCapsule tc "
+            + "WHERE tc.user.id = :userId AND tc.historyDate >= :start AND tc.historyDate < :end "
+            + "ORDER BY CAST(tc.historyDate AS DATE)")
     List<LocalDate> findActiveDatesInRange(@Param("userId") Long userId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
@@ -1,0 +1,39 @@
+package com.example.emotion_storage.timecapsule.service;
+
+import com.example.emotion_storage.global.api.ApiResponse;
+import com.example.emotion_storage.global.api.SuccessMessage;
+import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleExistDateResponse;
+import com.example.emotion_storage.timecapsule.repository.TimeCapsuleRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TimeCapsuleService {
+
+    private final TimeCapsuleRepository timeCapsuleRepository;
+
+    public ApiResponse<TimeCapsuleExistDateResponse> getMonthlyActiveDates(
+            int year, int month, Long userId
+    ) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDateTime start = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime end = yearMonth.plusMonths(1).atDay(1).atStartOfDay();
+
+        log.info("{}년 {}월 타임캡슐 날짜 목록을 조회합니다.", year, month);
+        List<LocalDate> dates =
+                timeCapsuleRepository.findActiveDatesInRange(userId, start, end);
+        int activeDays = dates.size();
+
+        return ApiResponse.success(
+                SuccessMessage.GET_MONTHLY_TIME_CAPSULE_DATES_SUCCESS.getMessage(),
+                new TimeCapsuleExistDateResponse(activeDays, dates)
+        );
+    }
+}

--- a/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
@@ -9,6 +9,7 @@ import com.example.emotion_storage.timecapsule.domain.TimeCapsuleOpenCost;
 import com.example.emotion_storage.timecapsule.dto.PaginationDto;
 import com.example.emotion_storage.timecapsule.dto.TimeCapsuleDto;
 import com.example.emotion_storage.timecapsule.dto.request.TimeCapsuleFavoriteRequest;
+import com.example.emotion_storage.timecapsule.dto.request.TimeCapsuleNoteUpdateRequest;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleExistDateResponse;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleFavoriteResponse;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleListResponse;
@@ -252,5 +253,15 @@ public class TimeCapsuleService {
 
         user.updateKeyCount(keys);
         log.info("열쇠 {}개를 사용했습니다. 남은 열쇠의 개수는 {}개입니다.", keys, user.getKeyCount());
+    }
+
+    @Transactional
+    public ApiResponse<Void> updateTimeCapsuleNote(Long timeCapsuleId, TimeCapsuleNoteUpdateRequest request, Long userId) {
+        TimeCapsule timeCapsule = findOwnedTimeCapsule(timeCapsuleId, userId);
+
+        log.info("타임캡슐 {}의 내 마음 노트를 업데이트 합니다.", timeCapsuleId);
+        timeCapsule.updateMyMindNote(request.content());
+
+        return ApiResponse.success(204, SuccessMessage.UPDATE_TIME_CAPSULE_MIND_NOTE_SUCCESS.getMessage(), null);
     }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
@@ -251,7 +251,7 @@ public class TimeCapsuleService {
             throw new BaseException(ErrorCode.TIME_CAPSULE_KEY_NOT_ENOUGH);
         }
 
-        user.updateKeyCount(keys);
+        user.useKeys(keys);
         log.info("열쇠 {}개를 사용했습니다. 남은 열쇠의 개수는 {}개입니다.", keys, user.getKeyCount());
     }
 

--- a/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
@@ -264,4 +264,14 @@ public class TimeCapsuleService {
 
         return ApiResponse.success(204, SuccessMessage.UPDATE_TIME_CAPSULE_MIND_NOTE_SUCCESS.getMessage(), null);
     }
+
+    @Transactional
+    public ApiResponse<Void> deleteTimeCapsule(Long timeCapsuleId, Long userId) {
+        TimeCapsule timeCapsule = findOwnedTimeCapsule(timeCapsuleId, userId);
+
+        log.info("타임캡슐 {}를 삭제합니다.", timeCapsuleId);
+        timeCapsule.setDeletedAt(LocalDateTime.now());
+
+        return ApiResponse.success(204, SuccessMessage.DELETE_TIME_CAPSULE_SUCCESS.getMessage(), null);
+    }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
@@ -10,6 +10,7 @@ import com.example.emotion_storage.timecapsule.dto.PaginationDto;
 import com.example.emotion_storage.timecapsule.dto.TimeCapsuleDto;
 import com.example.emotion_storage.timecapsule.dto.request.TimeCapsuleFavoriteRequest;
 import com.example.emotion_storage.timecapsule.dto.request.TimeCapsuleNoteUpdateRequest;
+import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleDetailResponse;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleExistDateResponse;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleFavoriteResponse;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleListResponse;
@@ -175,7 +176,7 @@ public class TimeCapsuleService {
 
     private List<TimeCapsuleDto> makeTimeCapsuleListFormat(Page<TimeCapsule> timeCapsules) {
         return timeCapsules.getContent().stream()
-                .map(TimeCapsuleDto::of)
+                .map(TimeCapsuleDto::from)
                 .toList();
     }
 
@@ -207,6 +208,13 @@ public class TimeCapsuleService {
         log.info("타임캡슐 {}을 즐겨찾기 목록에서 해제합니다.", timeCapsule.getId());
         timeCapsule.setFavoriteAt(null);
         timeCapsule.setIsFavorite(false);
+    }
+
+    public ApiResponse<TimeCapsuleDetailResponse> getTimeCapsuleDetail(Long timeCapsuleId, Long userId) {
+        TimeCapsule timeCapsule = findOwnedTimeCapsule(timeCapsuleId, userId);
+        log.info("타임캡슐 {}에 대한 상세 정보를 조회합니다.", timeCapsuleId);
+        TimeCapsuleDetailResponse response = TimeCapsuleDetailResponse.from(timeCapsule);
+        return ApiResponse.success(SuccessMessage.GET_TIME_CAPSULE_DETAIL_SUCCESS.getMessage(), response);
     }
 
     @Transactional

--- a/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
@@ -2,20 +2,33 @@ package com.example.emotion_storage.timecapsule.service;
 
 import com.example.emotion_storage.global.api.ApiResponse;
 import com.example.emotion_storage.global.api.SuccessMessage;
+import com.example.emotion_storage.timecapsule.domain.TimeCapsule;
+import com.example.emotion_storage.timecapsule.dto.PaginationDto;
+import com.example.emotion_storage.timecapsule.dto.TimeCapsuleDto;
 import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleExistDateResponse;
+import com.example.emotion_storage.timecapsule.dto.response.TimeCapsuleListResponse;
 import com.example.emotion_storage.timecapsule.repository.TimeCapsuleRepository;
+import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class TimeCapsuleService {
+
+    private static final String ARRIVED_STATUS = "arrived";
+    private static final String SORT_FOR_ARRIVED = "openedAt";
+    private static final String SORT_FOR_ALL = "historyDate";
 
     private final TimeCapsuleRepository timeCapsuleRepository;
 
@@ -26,14 +39,82 @@ public class TimeCapsuleService {
         LocalDateTime start = yearMonth.atDay(1).atStartOfDay();
         LocalDateTime end = yearMonth.plusMonths(1).atDay(1).atStartOfDay();
 
-        log.info("{}년 {}월 타임캡슐 날짜 목록을 조회합니다.", year, month);
+        log.info("{}년 {}월에 타임캡슐이 존재하는 날짜 목록을 조회합니다.", year, month);
         List<LocalDate> dates =
-                timeCapsuleRepository.findActiveDatesInRange(userId, start, end);
+                timeCapsuleRepository.findActiveDatesInRange(userId, start, end).stream()
+                        .map(Date::toLocalDate)
+                        .distinct()
+                        .toList();
+
         int activeDays = dates.size();
 
         return ApiResponse.success(
                 SuccessMessage.GET_MONTHLY_TIME_CAPSULE_DATES_SUCCESS.getMessage(),
                 new TimeCapsuleExistDateResponse(activeDays, dates)
         );
+    }
+
+    public ApiResponse<TimeCapsuleListResponse> getTimeCapsuleList(
+            LocalDate startDate, LocalDate endDate, int page, int limit, String status, Long userId
+    ) {
+        LocalDateTime start = startDate.atStartOfDay();
+        TimeCapsuleListResponse timeCapsuleList;
+        Pageable pageable;
+
+        if (ARRIVED_STATUS.equals(status)) {
+            log.info("사용자 {}의 {}-{}의 도착한 타임캡슐 목록을 조회합니다.", userId, startDate, endDate);
+            pageable = pageDesc(page, limit, SORT_FOR_ARRIVED);
+            LocalDateTime end = LocalDateTime.now();
+            timeCapsuleList = getArrivedTimeCapsuleList(start, end, page, limit, userId, pageable);
+        } else {
+            log.info("사용자 {}의 {}-{}의 타임캡슐 목록을 조회합니다.", userId, startDate, endDate);
+            pageable = pageDesc(page, limit, SORT_FOR_ALL);
+            LocalDateTime end = endDate.plusDays(1).atStartOfDay();
+            timeCapsuleList = getOneDayTimeCapsuleList(start, end, page, limit, userId, pageable);
+        }
+
+        return ApiResponse.success(SuccessMessage.GET_TIME_CAPSULE_LIST_SUCCESS.getMessage(), timeCapsuleList);
+    }
+
+    private Pageable pageDesc(int page, int limit, String sortField) {
+        return PageRequest.of(page, limit, Sort.by(sortField).descending());
+    }
+
+    private TimeCapsuleListResponse getOneDayTimeCapsuleList(
+            LocalDateTime start, LocalDateTime end, int page, int limit, Long userId, Pageable pageable
+    ) {
+        Page<TimeCapsule> timeCapsules =
+                timeCapsuleRepository.findByUser_IdAndDeletedAtIsNullAndHistoryDateBetween(
+                        userId, start, end, pageable
+                );
+        return getTimeCapsuleList(timeCapsules, page, limit);
+    }
+
+    private TimeCapsuleListResponse getArrivedTimeCapsuleList(
+            LocalDateTime start, LocalDateTime end, int page, int limit, Long userId, Pageable pageable
+    ) {
+        Page<TimeCapsule> timeCapsules =
+                timeCapsuleRepository.findByUser_IdAndDeletedAtIsNullAndOpenedAtGreaterThanEqualAndOpenedAtLessThanEqual(
+                        userId, start, end, pageable
+                );
+        return getTimeCapsuleList(timeCapsules, page, limit);
+    }
+
+    private TimeCapsuleListResponse getTimeCapsuleList(Page<TimeCapsule> timeCapsules, int page, int limit) {
+        List<TimeCapsuleDto> timeCapsuleList = makeTimeCapsuleListFormat(timeCapsules);
+
+        return new TimeCapsuleListResponse(
+                new PaginationDto(
+                        page, limit, timeCapsules.getTotalPages()
+                ),
+                timeCapsules.getNumberOfElements(),
+                timeCapsuleList
+        );
+    }
+
+    private List<TimeCapsuleDto> makeTimeCapsuleListFormat(Page<TimeCapsule> timeCapsules) {
+        return timeCapsules.getContent().stream()
+                .map(TimeCapsuleDto::of)
+                .toList();
     }
 }

--- a/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
@@ -129,7 +129,8 @@ public class TimeCapsuleService {
     }
 
     private Pageable pageDesc(int page, int limit, String sortField) {
-        return PageRequest.of(page, limit, Sort.by(sortField).descending());
+        int zeroBasedPage = Math.max(0, page - 1);
+        return PageRequest.of(zeroBasedPage, limit, Sort.by(sortField).descending());
     }
 
     private TimeCapsuleListResponse getOneDayTimeCapsuleList(

--- a/src/main/java/com/example/emotion_storage/user/auth/controller/AuthController.java
+++ b/src/main/java/com/example/emotion_storage/user/auth/controller/AuthController.java
@@ -2,6 +2,9 @@ package com.example.emotion_storage.user.auth.controller;
 
 import com.example.emotion_storage.global.api.ApiResponse;
 import com.example.emotion_storage.global.api.SuccessMessage;
+import com.example.emotion_storage.global.exception.BaseException;
+import com.example.emotion_storage.global.exception.ErrorCode;
+import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
 import com.example.emotion_storage.user.auth.dto.response.AccessTokenResponse;
 import com.example.emotion_storage.user.auth.dto.response.SessionResponse;
 import com.example.emotion_storage.user.auth.service.TokenService;
@@ -12,6 +15,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,7 +49,10 @@ public class AuthController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "액세스 토큰 만료")
     })
     @GetMapping("/session")
-    public ApiResponse<SessionResponse> checkSession() {
+    public ApiResponse<SessionResponse> checkSession(@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+        if (userPrincipal == null) {
+            throw new BaseException(ErrorCode.USER_NOT_FOUND);
+        }
         return ApiResponse.success(SuccessMessage.SESSION_CHECK_SUCCESS.getMessage(), SessionResponse.ok());
     }
 }

--- a/src/main/java/com/example/emotion_storage/user/domain/User.java
+++ b/src/main/java/com/example/emotion_storage/user/domain/User.java
@@ -112,7 +112,7 @@ public class User extends BaseTimeEntity {
         notification.setUser(null);
     }
 
-    public void updateKeyCount(Long keyCount) {
+    public void useKeys(Long keyCount) {
         this.keyCount -= keyCount;
     }
 }

--- a/src/main/java/com/example/emotion_storage/user/domain/User.java
+++ b/src/main/java/com/example/emotion_storage/user/domain/User.java
@@ -111,4 +111,8 @@ public class User extends BaseTimeEntity {
         this.notifications.remove(notification);
         notification.setUser(null);
     }
+
+    public void updateKeyCount(Long keyCount) {
+        this.keyCount -= keyCount;
+    }
 }


### PR DESCRIPTION
## ✨ 작업 내용
- 해당년월에 타임캡슐이 존재하는 날짜 목록 조회
- 타임캡슐 목록 조회(도착한 타임캡슐 및 특정 날짜의 타임캡슐 목록)
- 즐겨찾기 타임캡슐 목록 조회
- 타임캡슐 즐겨찾기 추가 및 해제
- 타임캡슐 열림 상태 갱신
- 타임캡슐 상세 조회
- 타임캡슐 마음노트 수정
- 타임캡슐 삭제

---

## 📝 적용 범위
- `/timecapsule`
- `/user`

---

## 📌 참고 사항
- 관련 이슈(#49)