### PR TITLE
feat: 일일리포트 조회 API 구현

### DIFF
--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -32,6 +32,9 @@ public enum SuccessMessage {
     OPEN_TIME_CAPSULE_SUCCESS("타임캡슐 열람 성공"),
     UPDATE_TIME_CAPSULE_MIND_NOTE_SUCCESS("타임캡슐 내 마음 노트 수정 성공"),
     DELETE_TIME_CAPSULE_SUCCESS("타임캡슐 삭제 성공"),
+    
+    // Report
+    DAILY_REPORT_DETAIL_GET_SUCCESS("일일리포트 상세 조회 성공"),
     ;
 
     private final String message;

--- a/src/main/java/com/example/emotion_storage/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/emotion_storage/global/exception/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
     TIME_CAPSULE_OPEN_RULE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "열람 비용 규칙이 정의되어 있지 않습니다."),
     
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "리포트를 찾을 수 없습니다."),
+    DAILY_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "일일리포트 조회 실패 - 존재하지 않음"),
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 날짜 형식입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/emotion_storage/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/emotion_storage/global/exception/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
     TIME_CAPSULE_FAVORITE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "즐겨찾기는 최대 30개까지만 가능합니다."),
     TIME_CAPSULE_KEY_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "열쇠가 부족하여 타임캡슐을 열 수 없습니다."),
     TIME_CAPSULE_OPEN_RULE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "열람 비용 규칙이 정의되어 있지 않습니다."),
+    
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "리포트를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/emotion_storage/report/controller/ReportController.java
+++ b/src/main/java/com/example/emotion_storage/report/controller/ReportController.java
@@ -2,15 +2,16 @@ package com.example.emotion_storage.report.controller;
 
 import com.example.emotion_storage.global.api.ApiResponse;
 import com.example.emotion_storage.global.api.SuccessMessage;
+import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
 import com.example.emotion_storage.report.dto.response.DailyReportDetailResponse;
 import com.example.emotion_storage.report.service.ReportService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -22,15 +23,24 @@ public class ReportController {
 
     private final ReportService reportService;
 
-    @GetMapping("/daily-report/{reportId}")
-    @Operation(summary = "일일리포트 상세 조회", description = "특정 일일리포트의 상세 정보를 조회합니다.")
+    @GetMapping("/daily-report")
+    @Operation(summary = "일일리포트 상세 조회", description = "특정 날짜의 일일리포트 상세 정보를 조회합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "일일리포트 상세 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 날짜 형식"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리포트를 찾을 수 없음")
+    })
     public ResponseEntity<ApiResponse<DailyReportDetailResponse>> getDailyReportDetail(
-            @Parameter(description = "리포트 ID", required = true, example = "1")
-            @PathVariable Long reportId) {
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd 형식)", required = true, example = "2025-09-01")
+            @RequestParam String date,
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
         
-        log.info("일일리포트 상세 조회 API 호출 - reportId: {}", reportId);
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("일일리포트 상세 조회 API 호출 - userId: {}, date: {}", userId, date);
         
-        DailyReportDetailResponse response = reportService.getDailyReportDetail(reportId);
+        DailyReportDetailResponse response = reportService.getDailyReportDetail(userId, date);
         
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessMessage.DAILY_REPORT_DETAIL_GET_SUCCESS.getMessage(), response)

--- a/src/main/java/com/example/emotion_storage/report/controller/ReportController.java
+++ b/src/main/java/com/example/emotion_storage/report/controller/ReportController.java
@@ -1,0 +1,39 @@
+package com.example.emotion_storage.report.controller;
+
+import com.example.emotion_storage.global.api.ApiResponse;
+import com.example.emotion_storage.global.api.SuccessMessage;
+import com.example.emotion_storage.report.dto.response.DailyReportDetailResponse;
+import com.example.emotion_storage.report.service.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "일일리포트", description = "일일리포트 관련 API")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @GetMapping("/daily-report/{reportId}")
+    @Operation(summary = "일일리포트 상세 조회", description = "특정 일일리포트의 상세 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<DailyReportDetailResponse>> getDailyReportDetail(
+            @Parameter(description = "리포트 ID", required = true, example = "1")
+            @PathVariable Long reportId) {
+        
+        log.info("일일리포트 상세 조회 API 호출 - reportId: {}", reportId);
+        
+        DailyReportDetailResponse response = reportService.getDailyReportDetail(reportId);
+        
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessMessage.DAILY_REPORT_DETAIL_GET_SUCCESS.getMessage(), response)
+        );
+    }
+}

--- a/src/main/java/com/example/emotion_storage/report/domain/EmotionVariation.java
+++ b/src/main/java/com/example/emotion_storage/report/domain/EmotionVariation.java
@@ -4,6 +4,8 @@ import com.example.emotion_storage.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Table(name = "emotion_variation")
@@ -14,15 +16,18 @@ public class EmotionVariation extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "expectation_id")
+    @Column(name = "emotion_variation_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "report_id", nullable = false)
     private Report report;
 
-    @Column(nullable = false, length = 500)
-    private String expectation;
+    @Column(nullable = false)
+    private LocalDateTime time;
+
+    @Column(nullable = false, length = 30)
+    private String label;
 
     public void setReport(Report report) {
         this.report = report;

--- a/src/main/java/com/example/emotion_storage/report/domain/Keyword.java
+++ b/src/main/java/com/example/emotion_storage/report/domain/Keyword.java
@@ -1,0 +1,29 @@
+package com.example.emotion_storage.report.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "keywords")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Keyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "keyword_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String keyword;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id", nullable = false)
+    private Report report;
+
+    public void setReport(Report report) {
+        this.report = report;
+    }
+}

--- a/src/main/java/com/example/emotion_storage/report/domain/Report.java
+++ b/src/main/java/com/example/emotion_storage/report/domain/Report.java
@@ -37,8 +37,9 @@ public class Report extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String emotionSummary;
 
-    @Column(columnDefinition = "TEXT", nullable = false)
-    private String keywords;
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Keyword> keywords = new ArrayList<>();
 
     @Column(nullable = false)
     private Boolean isOpened;
@@ -69,5 +70,10 @@ public class Report extends BaseTimeEntity {
     public void removeTimeCapsule(TimeCapsule timeCapsule) {
         this.timeCapsules.remove(timeCapsule);
         timeCapsule.setReport(null);
+    }
+
+    public void addKeyword(Keyword keyword) {
+        this.keywords.add(keyword);
+        keyword.setReport(this);
     }
 }

--- a/src/main/java/com/example/emotion_storage/report/dto/response/DailyReportDetailResponse.java
+++ b/src/main/java/com/example/emotion_storage/report/dto/response/DailyReportDetailResponse.java
@@ -1,0 +1,66 @@
+package com.example.emotion_storage.report.dto.response;
+
+import com.example.emotion_storage.report.domain.EmotionVariation;
+import com.example.emotion_storage.report.domain.Keyword;
+import com.example.emotion_storage.report.domain.Report;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DailyReportDetailResponse {
+
+    private Long id;
+    private String createdAt;
+    private String updatedAt;
+    private List<String> summaries;
+    private List<String> keywords;
+    private Integer stressIndex;
+    private Integer happinessIndex;
+    private String emotionSummary;
+    private List<EmotionChangeDto> emotionChanges;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class EmotionChangeDto {
+        private String time;
+        private String label;
+    }
+
+    public static DailyReportDetailResponse from(Report report) {
+        return DailyReportDetailResponse.builder()
+                .id(report.getId())
+                .createdAt(formatDateTime(report.getCreatedAt()))
+                .updatedAt(formatDateTime(report.getUpdatedAt()))
+                .summaries(List.of(report.getTodaySummary()))
+                .keywords(report.getKeywords().stream()
+                        .map(Keyword::getKeyword)
+                        .collect(Collectors.toList()))
+                .stressIndex(report.getStressIndex())
+                .happinessIndex(report.getHappinessIndex())
+                .emotionSummary(report.getEmotionSummary())
+                .emotionChanges(report.getEmotionVariations().stream()
+                        .map(emotionVariation -> EmotionChangeDto.builder()
+                                .time(formatTime(emotionVariation.getTime()))
+                                .label(emotionVariation.getLabel())
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    private static String formatDateTime(LocalDateTime dateTime) {
+        return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+
+    private static String formatTime(LocalDateTime dateTime) {
+        return dateTime.format(DateTimeFormatter.ofPattern("HH:mm"));
+    }
+}

--- a/src/main/java/com/example/emotion_storage/report/repository/KeywordRepository.java
+++ b/src/main/java/com/example/emotion_storage/report/repository/KeywordRepository.java
@@ -1,0 +1,13 @@
+package com.example.emotion_storage.report.repository;
+
+import com.example.emotion_storage.report.domain.Keyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+    
+    List<Keyword> findByReportId(Long reportId);
+}

--- a/src/main/java/com/example/emotion_storage/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/emotion_storage/report/repository/ReportRepository.java
@@ -6,18 +6,19 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.time.LocalDate;
+import java.util.Optional;
 
 @Repository
 public interface ReportRepository extends JpaRepository<Report, Long> {
-    
-    @Query("SELECT DISTINCT r FROM Report r " +
-           "JOIN r.timeCapsules tc " +
-           "WHERE tc.user.id = :userId AND r.isOpened = false")
-    List<Report> findUnopenedReportsByUserId(@Param("userId") Long userId);
     
     @Query("SELECT COUNT(DISTINCT r) FROM Report r " +
            "JOIN r.timeCapsules tc " +
            "WHERE tc.user.id = :userId AND r.isOpened = false")
     Long countUnopenedReportsByUserId(@Param("userId") Long userId);
+    
+    @Query("SELECT DISTINCT r FROM Report r " +
+           "JOIN r.timeCapsules tc " +
+           "WHERE tc.user.id = :userId AND r.historyDate = :historyDate")
+    Optional<Report> findByUserIdAndHistoryDate(@Param("userId") Long userId, @Param("historyDate") LocalDate historyDate);
 }

--- a/src/main/java/com/example/emotion_storage/report/service/ReportService.java
+++ b/src/main/java/com/example/emotion_storage/report/service/ReportService.java
@@ -1,0 +1,39 @@
+package com.example.emotion_storage.report.service;
+
+import com.example.emotion_storage.global.exception.BaseException;
+import com.example.emotion_storage.global.exception.ErrorCode;
+import com.example.emotion_storage.report.domain.Report;
+import com.example.emotion_storage.report.dto.response.DailyReportDetailResponse;
+import com.example.emotion_storage.report.repository.ReportRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+
+    public DailyReportDetailResponse getDailyReportDetail(Long reportId) {
+        log.info("일일리포트 상세 조회 요청 - reportId: {}", reportId);
+        
+        Report report = findReportWithDetails(reportId);
+        
+        DailyReportDetailResponse response = DailyReportDetailResponse.from(report);
+        
+        log.info("일일리포트 상세 조회 완료 - reportId: {}", reportId);
+        return response;
+    }
+
+    private Report findReportWithDetails(Long reportId) {
+        return reportRepository.findById(reportId)
+                .orElseThrow(() -> {
+                    log.warn("존재하지 않는 리포트 조회 시도 - reportId: {}", reportId);
+                    return new BaseException(ErrorCode.REPORT_NOT_FOUND);
+                });
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
- 날짜 기반 일일리포트 조회 API 구현

---

## 📝 적용 범위
- `report/`

---

## 📌 참고 사항
- #21 

close #21 