### PR TITLE
feat: 마이페이지 API 구현

### DIFF
--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -42,6 +42,7 @@ public enum SuccessMessage {
     CHANGE_USER_NICKNAME_SUCCESS("사용자 닉네임 업데이트 성공"),
     GET_USER_ACCOUNT_INFO_SUCCESS("사용자 계정 정보 조회 성공"),
     GET_NOTIFICATION_SETTINGS_SUCCESS("사용자 알림 설정 상태 정보 조회 성공"),
+    GET_POLICY_SUCCESS("이용 약관 및 개인정보 처리방침 조회 성공"),
     ;
 
     private final String message;

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -42,7 +42,9 @@ public enum SuccessMessage {
     CHANGE_USER_NICKNAME_SUCCESS("사용자 닉네임 업데이트 성공"),
     GET_USER_ACCOUNT_INFO_SUCCESS("사용자 계정 정보 조회 성공"),
     GET_NOTIFICATION_SETTINGS_SUCCESS("사용자 알림 설정 상태 정보 조회 성공"),
+    UPDATE_NOTIFICATION_SETTINGS_SUCCESS("사용자 알림 설정 상태 정보 업데이트 성공"),
     GET_POLICY_SUCCESS("이용 약관 및 개인정보 처리방침 조회 성공"),
+    WITHDRAW_USER_SUCCESS("회원 탈퇴 처리 성공"),
     ;
 
     private final String message;

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -40,6 +40,7 @@ public enum SuccessMessage {
     // My Page
     GET_MY_PAGE_USER_INFO_SUCCESS("마이페이지 내 사용자 정보 조회 성공"),
     CHANGE_USER_NICKNAME_SUCCESS("사용자 닉네임 업데이트 성공"),
+    GET_USER_ACCOUNT_INFO_SUCCESS("사용자 계정 정보 조회 성공"),
     ;
 
     private final String message;

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -45,6 +45,7 @@ public enum SuccessMessage {
     UPDATE_NOTIFICATION_SETTINGS_SUCCESS("사용자 알림 설정 상태 정보 업데이트 성공"),
     GET_POLICY_SUCCESS("이용 약관 및 개인정보 처리방침 조회 성공"),
     WITHDRAW_USER_SUCCESS("회원 탈퇴 처리 성공"),
+    LOGOUT_USER_SUCCESS("회원 로그아웃 처리 성공"),
     ;
 
     private final String message;

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -39,6 +39,7 @@ public enum SuccessMessage {
 
     // My Page
     GET_MY_PAGE_USER_INFO_SUCCESS("마이페이지 내 사용자 정보 조회 성공"),
+    CHANGE_USER_NICKNAME_SUCCESS("사용자 닉네임 업데이트 성공"),
     ;
 
     private final String message;

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -41,6 +41,7 @@ public enum SuccessMessage {
     GET_MY_PAGE_USER_INFO_SUCCESS("마이페이지 내 사용자 정보 조회 성공"),
     CHANGE_USER_NICKNAME_SUCCESS("사용자 닉네임 업데이트 성공"),
     GET_USER_ACCOUNT_INFO_SUCCESS("사용자 계정 정보 조회 성공"),
+    GET_NOTIFICATION_SETTINGS_SUCCESS("사용자 알림 설정 상태 정보 조회 성공"),
     ;
 
     private final String message;

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -36,6 +36,9 @@ public enum SuccessMessage {
     
     // Report
     DAILY_REPORT_DETAIL_GET_SUCCESS("일일리포트 상세 조회 성공"),
+
+    // My Page
+    GET_MY_PAGE_USER_INFO_SUCCESS("마이페이지 내 사용자 정보 조회 성공"),
     ;
 
     private final String message;

--- a/src/main/java/com/example/emotion_storage/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/emotion_storage/global/config/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.emotion_storage.global.config.security;
 import com.example.emotion_storage.global.security.jwt.JwtAuthEntryPoint;
 import com.example.emotion_storage.global.security.jwt.JwtTokenProvider;
 import com.example.emotion_storage.global.security.jwt.TokenAuthenticationFilter;
+import com.example.emotion_storage.user.auth.service.RedisService;
 import com.example.emotion_storage.user.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final RedisService redisService;
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
     private final JwtAuthEntryPoint jwtAuthEntryPoint;
@@ -73,6 +75,6 @@ public class SecurityConfig {
 
     @Bean
     public TokenAuthenticationFilter tokenAuthenticationFilter() {
-        return new TokenAuthenticationFilter(jwtTokenProvider, userRepository);
+        return new TokenAuthenticationFilter(redisService, jwtTokenProvider, userRepository);
     }
 }

--- a/src/main/java/com/example/emotion_storage/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/emotion_storage/global/exception/ErrorCode.java
@@ -33,6 +33,9 @@ public enum ErrorCode {
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "리포트를 찾을 수 없습니다."),
     DAILY_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "일일리포트 조회 실패 - 존재하지 않음"),
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 날짜 형식입니다."),
+
+    EMOTION_REMINDER_DAYS_REQUIRED(HttpStatus.BAD_REQUEST, "감정 기록 알림 요일이 필요합니다."),
+    EMOTION_REMINDER_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "감정 기록 알림 시간이 필요합니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/emotion_storage/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/emotion_storage/global/security/jwt/JwtTokenProvider.java
@@ -55,12 +55,24 @@ public class JwtTokenProvider {
     }
 
     public Long getUserIdFromToken(String token) {
-        Claims claims =  Jwts.parserBuilder()
+        Claims claims = Jwts.parserBuilder()
                 .setSigningKey(secretKey)
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
 
         return Long.parseLong(claims.getSubject());
+    }
+
+    public long getRemainingMillis(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        long exp = claims.getExpiration().getTime();
+        long now = System.currentTimeMillis();
+        return Math.max(0L, exp - now);
     }
 }

--- a/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
+++ b/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -93,16 +94,31 @@ public class MyPageController {
         log.info("사용자 {}의 알림설정 상태 업데이트를 요청받았습니다.", userId);
         myPageService.updateNotificationSettings(request, userId);
         return ResponseEntity.ok(ApiResponse.success(
-                SuccessMessage.GET_NOTIFICATION_SETTINGS_SUCCESS.getMessage(), null));
+                HttpStatus.NO_CONTENT.value(),
+                SuccessMessage.UPDATE_NOTIFICATION_SETTINGS_SUCCESS.getMessage(),
+                null));
     }
 
     @GetMapping("/policy")
     @Operation(summary = "이용 약관 및 개인정보 처리방침 조회 API", description = "이용 약관 및 개인정보 처리방침을 반환합니다.")
-    public ResponseEntity<ApiResponse<PolicyResponse>> getPolicy(
-    ) {
+    public ResponseEntity<ApiResponse<PolicyResponse>> getPolicy() {
         log.info("이용 약관 및 개인정보 처리방침을 조회합니다.");
         PolicyResponse response = myPageService.getPolicy();
         return ResponseEntity.ok(ApiResponse.success(
                 SuccessMessage.GET_POLICY_SUCCESS.getMessage(), response));
+    }
+
+    @DeleteMapping("/account")
+    @Operation(summary = "회원 탈퇴 API", description = "회원 탈퇴를 진행합니다.")
+    public ResponseEntity<ApiResponse<Void>> withdrawUser(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("회원 {}의 탈퇴를 요청받았습니다.", userId);
+        myPageService.withdrawUser(userId);
+        return ResponseEntity.ok(ApiResponse.success(
+                HttpStatus.NO_CONTENT.value(),
+                SuccessMessage.WITHDRAW_USER_SUCCESS.getMessage(),
+                null));
     }
 }

--- a/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
+++ b/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
@@ -1,0 +1,38 @@
+package com.example.emotion_storage.mypage.controller;
+
+import com.example.emotion_storage.global.api.ApiResponse;
+import com.example.emotion_storage.global.api.SuccessMessage;
+import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
+import com.example.emotion_storage.mypage.dto.response.UserInfoResponse;
+import com.example.emotion_storage.mypage.service.MyPageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/mypage")
+@RequiredArgsConstructor
+@Tag(name = "MyPage", description = "마이페이지 관련 API")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping
+    @Operation(summary = "유저 정보 API", description = "닉네임, 가입 기간, 보유 열쇠를 반환합니다.")
+    public ResponseEntity<ApiResponse<UserInfoResponse>> createChatRoomForTest(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}의 마이페이지 내 정보 조회를 요청받았습니다.", userId);
+        UserInfoResponse response = myPageService.getUserInfo(userId);
+        return ResponseEntity.ok(ApiResponse.success(
+                SuccessMessage.GET_MY_PAGE_USER_INFO_SUCCESS.getMessage(), response));
+    }
+}

--- a/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
+++ b/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
@@ -4,6 +4,7 @@ import com.example.emotion_storage.global.api.ApiResponse;
 import com.example.emotion_storage.global.api.SuccessMessage;
 import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
 import com.example.emotion_storage.mypage.dto.request.NicknameChangeRequest;
+import com.example.emotion_storage.mypage.dto.request.NotificationSettingsUpdateRequest;
 import com.example.emotion_storage.mypage.dto.response.MyPageOverviewResponse;
 import com.example.emotion_storage.mypage.dto.response.NotificationSettingsResponse;
 import com.example.emotion_storage.mypage.dto.response.UserAccountInfoResponse;
@@ -79,5 +80,18 @@ public class MyPageController {
         NotificationSettingsResponse response = myPageService.getNotificationSettings(userId);
         return ResponseEntity.ok(ApiResponse.success(
                 SuccessMessage.GET_NOTIFICATION_SETTINGS_SUCCESS.getMessage(), response));
+    }
+
+    @PatchMapping("/notification-settings")
+    @Operation(summary = "사용자 알림 설정 상태 업데이트 API", description = "사용자가 선택한 알림 설정 상태를 업데이트 합니다.")
+    public ResponseEntity<ApiResponse<Void>> updateNotificationSettings(
+            @RequestBody NotificationSettingsUpdateRequest request,
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}의 알림설정 상태 업데이트를 요청받았습니다.", userId);
+        myPageService.updateNotificationSettings(request, userId);
+        return ResponseEntity.ok(ApiResponse.success(
+                SuccessMessage.GET_NOTIFICATION_SETTINGS_SUCCESS.getMessage(), null));
     }
 }

--- a/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
+++ b/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
@@ -3,15 +3,19 @@ package com.example.emotion_storage.mypage.controller;
 import com.example.emotion_storage.global.api.ApiResponse;
 import com.example.emotion_storage.global.api.SuccessMessage;
 import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
+import com.example.emotion_storage.mypage.dto.request.NicknameChangeRequest;
 import com.example.emotion_storage.mypage.dto.response.UserInfoResponse;
 import com.example.emotion_storage.mypage.service.MyPageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -34,5 +38,20 @@ public class MyPageController {
         UserInfoResponse response = myPageService.getUserInfo(userId);
         return ResponseEntity.ok(ApiResponse.success(
                 SuccessMessage.GET_MY_PAGE_USER_INFO_SUCCESS.getMessage(), response));
+    }
+
+    @PatchMapping("/nickname")
+    @Operation(summary = "닉네임 수정 API", description = "사용자의 닉네임을 수정합니다.")
+    public ResponseEntity<ApiResponse<Void>> changeUserNickname(
+            @RequestBody NicknameChangeRequest request,
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}의 닉네임 수정을 요청받았습니다.", userId);
+        myPageService.changeUserNickname(request, userId);
+        return ResponseEntity.ok(ApiResponse.success(
+                HttpStatus.NO_CONTENT.value(),
+                SuccessMessage.CHANGE_USER_NICKNAME_SUCCESS.getMessage(),
+                null));
     }
 }

--- a/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
+++ b/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
@@ -4,7 +4,8 @@ import com.example.emotion_storage.global.api.ApiResponse;
 import com.example.emotion_storage.global.api.SuccessMessage;
 import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
 import com.example.emotion_storage.mypage.dto.request.NicknameChangeRequest;
-import com.example.emotion_storage.mypage.dto.response.UserInfoResponse;
+import com.example.emotion_storage.mypage.dto.response.MyPageOverviewResponse;
+import com.example.emotion_storage.mypage.dto.response.UserAccountInfoResponse;
 import com.example.emotion_storage.mypage.service.MyPageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,13 +30,13 @@ public class MyPageController {
     private final MyPageService myPageService;
 
     @GetMapping
-    @Operation(summary = "유저 정보 API", description = "닉네임, 가입 기간, 보유 열쇠를 반환합니다.")
-    public ResponseEntity<ApiResponse<UserInfoResponse>> createChatRoomForTest(
+    @Operation(summary = "먀이페이지 초기 화면 조회 API", description = "닉네임, 가입 기간, 보유 열쇠를 반환합니다.")
+    public ResponseEntity<ApiResponse<MyPageOverviewResponse>> getMyPageOverview(
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal
     ) {
         Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
         log.info("사용자 {}의 마이페이지 내 정보 조회를 요청받았습니다.", userId);
-        UserInfoResponse response = myPageService.getUserInfo(userId);
+        MyPageOverviewResponse response = myPageService.getMyPageOverview(userId);
         return ResponseEntity.ok(ApiResponse.success(
                 SuccessMessage.GET_MY_PAGE_USER_INFO_SUCCESS.getMessage(), response));
     }
@@ -53,5 +54,17 @@ public class MyPageController {
                 HttpStatus.NO_CONTENT.value(),
                 SuccessMessage.CHANGE_USER_NICKNAME_SUCCESS.getMessage(),
                 null));
+    }
+
+    @GetMapping
+    @Operation(summary = "사용자 계정 정보 API", description = "이메일, 연동 정보 등을 반환합니다.")
+    public ResponseEntity<ApiResponse<UserAccountInfoResponse>> getUserAccountInfo(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}의 계정 정보 조회를 요청받았습니다.", userId);
+        UserAccountInfoResponse response = myPageService.getUserAccountInfo(userId);
+        return ResponseEntity.ok(ApiResponse.success(
+                SuccessMessage.GET_USER_ACCOUNT_INFO_SUCCESS.getMessage(), response));
     }
 }

--- a/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
+++ b/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
@@ -7,6 +7,7 @@ import com.example.emotion_storage.mypage.dto.request.NicknameChangeRequest;
 import com.example.emotion_storage.mypage.dto.request.NotificationSettingsUpdateRequest;
 import com.example.emotion_storage.mypage.dto.response.MyPageOverviewResponse;
 import com.example.emotion_storage.mypage.dto.response.NotificationSettingsResponse;
+import com.example.emotion_storage.mypage.dto.response.PolicyResponse;
 import com.example.emotion_storage.mypage.dto.response.UserAccountInfoResponse;
 import com.example.emotion_storage.mypage.service.MyPageService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -93,5 +94,15 @@ public class MyPageController {
         myPageService.updateNotificationSettings(request, userId);
         return ResponseEntity.ok(ApiResponse.success(
                 SuccessMessage.GET_NOTIFICATION_SETTINGS_SUCCESS.getMessage(), null));
+    }
+
+    @GetMapping("/policy")
+    @Operation(summary = "이용 약관 및 개인정보 처리방침 조회 API", description = "이용 약관 및 개인정보 처리방침을 반환합니다.")
+    public ResponseEntity<ApiResponse<PolicyResponse>> getPolicy(
+    ) {
+        log.info("이용 약관 및 개인정보 처리방침을 조회합니다.");
+        PolicyResponse response = myPageService.getPolicy();
+        return ResponseEntity.ok(ApiResponse.success(
+                SuccessMessage.GET_POLICY_SUCCESS.getMessage(), response));
     }
 }

--- a/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
+++ b/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
@@ -12,6 +12,8 @@ import com.example.emotion_storage.mypage.dto.response.UserAccountInfoResponse;
 import com.example.emotion_storage.mypage.service.MyPageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -20,6 +22,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -111,14 +114,30 @@ public class MyPageController {
     @DeleteMapping("/account")
     @Operation(summary = "회원 탈퇴 API", description = "회원 탈퇴를 진행합니다.")
     public ResponseEntity<ApiResponse<Void>> withdrawUser(
-            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+            HttpServletRequest request, HttpServletResponse response
     ) {
         Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
         log.info("회원 {}의 탈퇴를 요청받았습니다.", userId);
-        myPageService.withdrawUser(userId);
+        myPageService.withdrawUser(userId, request, response);
         return ResponseEntity.ok(ApiResponse.success(
                 HttpStatus.NO_CONTENT.value(),
                 SuccessMessage.WITHDRAW_USER_SUCCESS.getMessage(),
+                null));
+    }
+
+    @DeleteMapping("/logout")
+    @Operation(summary = "로그아웃 API", description = "로그아웃을 진행합니다.")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+            HttpServletRequest request, HttpServletResponse response
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("회원 {}의 로그아웃을 요청받았습니다.", userId);
+        myPageService.logout(userId, request, response);
+        return ResponseEntity.ok(ApiResponse.success(
+                HttpStatus.NO_CONTENT.value(),
+                SuccessMessage.LOGOUT_USER_SUCCESS.getMessage(),
                 null));
     }
 }

--- a/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
+++ b/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
@@ -5,6 +5,7 @@ import com.example.emotion_storage.global.api.SuccessMessage;
 import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
 import com.example.emotion_storage.mypage.dto.request.NicknameChangeRequest;
 import com.example.emotion_storage.mypage.dto.response.MyPageOverviewResponse;
+import com.example.emotion_storage.mypage.dto.response.NotificationSettingsResponse;
 import com.example.emotion_storage.mypage.dto.response.UserAccountInfoResponse;
 import com.example.emotion_storage.mypage.service.MyPageService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -56,8 +57,8 @@ public class MyPageController {
                 null));
     }
 
-    @GetMapping
-    @Operation(summary = "사용자 계정 정보 API", description = "이메일, 연동 정보 등을 반환합니다.")
+    @GetMapping("/profile")
+    @Operation(summary = "사용자 계정 정보 조회 API", description = "이메일, 연동 정보 등을 반환합니다.")
     public ResponseEntity<ApiResponse<UserAccountInfoResponse>> getUserAccountInfo(
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal
     ) {
@@ -66,5 +67,17 @@ public class MyPageController {
         UserAccountInfoResponse response = myPageService.getUserAccountInfo(userId);
         return ResponseEntity.ok(ApiResponse.success(
                 SuccessMessage.GET_USER_ACCOUNT_INFO_SUCCESS.getMessage(), response));
+    }
+
+    @GetMapping("/notification-settings")
+    @Operation(summary = "사용자 알림설정 상태 정보 조회 API", description = "사용자가 알림설정 상태를 설정한 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<NotificationSettingsResponse>> getNotificationSettings(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}의 알림설정 상태 정보 조회를 요청받았습니다.", userId);
+        NotificationSettingsResponse response = myPageService.getNotificationSettings(userId);
+        return ResponseEntity.ok(ApiResponse.success(
+                SuccessMessage.GET_NOTIFICATION_SETTINGS_SUCCESS.getMessage(), response));
     }
 }

--- a/src/main/java/com/example/emotion_storage/mypage/dto/request/NicknameChangeRequest.java
+++ b/src/main/java/com/example/emotion_storage/mypage/dto/request/NicknameChangeRequest.java
@@ -1,0 +1,5 @@
+package com.example.emotion_storage.mypage.dto.request;
+
+public record NicknameChangeRequest(
+        String nickname
+) {}

--- a/src/main/java/com/example/emotion_storage/mypage/dto/request/NotificationSettingsUpdateRequest.java
+++ b/src/main/java/com/example/emotion_storage/mypage/dto/request/NotificationSettingsUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.emotion_storage.mypage.dto.request;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.Set;
+
+public record NotificationSettingsUpdateRequest(
+        boolean appPushNotify,
+        boolean emotionReminderNotify,
+        Set<DayOfWeek> emotionReminderDays,
+        LocalTime emotionReminderTime,
+        boolean timeCapsuleReportNotify,
+        boolean marketingInfoNotify
+) {}

--- a/src/main/java/com/example/emotion_storage/mypage/dto/response/MyPageOverviewResponse.java
+++ b/src/main/java/com/example/emotion_storage/mypage/dto/response/MyPageOverviewResponse.java
@@ -1,6 +1,6 @@
 package com.example.emotion_storage.mypage.dto.response;
 
-public record UserInfoResponse(
+public record MyPageOverviewResponse(
         String nickname,
         long days,
         long keys

--- a/src/main/java/com/example/emotion_storage/mypage/dto/response/NotificationSettingsResponse.java
+++ b/src/main/java/com/example/emotion_storage/mypage/dto/response/NotificationSettingsResponse.java
@@ -1,0 +1,14 @@
+package com.example.emotion_storage.mypage.dto.response;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.Set;
+
+public record NotificationSettingsResponse(
+        boolean appPushNotify,
+        boolean emotionReminderNotify,
+        Set<DayOfWeek> emotionReminderDays,
+        LocalTime emotionReminderTime,
+        boolean timeCapsuleReportNotify,
+        boolean marketingInfoNotify
+) {}

--- a/src/main/java/com/example/emotion_storage/mypage/dto/response/PolicyResponse.java
+++ b/src/main/java/com/example/emotion_storage/mypage/dto/response/PolicyResponse.java
@@ -1,0 +1,5 @@
+package com.example.emotion_storage.mypage.dto.response;
+
+public record PolicyResponse(
+        String policy
+) {}

--- a/src/main/java/com/example/emotion_storage/mypage/dto/response/UserAccountInfoResponse.java
+++ b/src/main/java/com/example/emotion_storage/mypage/dto/response/UserAccountInfoResponse.java
@@ -1,0 +1,12 @@
+package com.example.emotion_storage.mypage.dto.response;
+
+import com.example.emotion_storage.user.domain.Gender;
+import com.example.emotion_storage.user.domain.SocialType;
+import java.time.LocalDate;
+
+public record UserAccountInfoResponse(
+        String email,
+        SocialType socialType,
+        Gender gender,
+        LocalDate birthday
+) {}

--- a/src/main/java/com/example/emotion_storage/mypage/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/example/emotion_storage/mypage/dto/response/UserInfoResponse.java
@@ -1,0 +1,7 @@
+package com.example.emotion_storage.mypage.dto.response;
+
+public record UserInfoResponse(
+        String nickname,
+        long days,
+        long keys
+) {}

--- a/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
+++ b/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
@@ -3,6 +3,7 @@ package com.example.emotion_storage.mypage.service;
 import com.example.emotion_storage.global.exception.BaseException;
 import com.example.emotion_storage.global.exception.ErrorCode;
 import com.example.emotion_storage.mypage.dto.request.NicknameChangeRequest;
+import com.example.emotion_storage.mypage.dto.request.NotificationSettingsUpdateRequest;
 import com.example.emotion_storage.mypage.dto.response.MyPageOverviewResponse;
 import com.example.emotion_storage.mypage.dto.response.NotificationSettingsResponse;
 import com.example.emotion_storage.mypage.dto.response.UserAccountInfoResponse;
@@ -61,6 +62,22 @@ public class MyPageService {
                 user.isTimeCapsuleReportNotify(),
                 user.isMarketingInfoNotify()
         );
+    }
+
+    public void updateNotificationSettings(NotificationSettingsUpdateRequest request, Long userId) {
+        User user = findUserById(userId);
+
+        log.info("사용자 {}의 알림 설정 상태를 업데이트합니다.", userId);
+
+        user.updateAppPushNotify(request.appPushNotify());
+
+        user.updateEmotionReminderNotify(request.emotionReminderNotify());
+        user.getEmotionReminderDays().clear();
+        user.getEmotionReminderDays().addAll(request.emotionReminderDays());
+        user.updateEmotionReminderTime(request.emotionReminderTime());
+
+        user.updateTimeCapsuleReportNotify(request.timeCapsuleReportNotify());
+        user.updateMarketingInfoNotify(request.marketingInfoNotify());
     }
 
     private User findUserById(Long userId) {

--- a/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
+++ b/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
@@ -6,6 +6,7 @@ import com.example.emotion_storage.mypage.dto.request.NicknameChangeRequest;
 import com.example.emotion_storage.mypage.dto.request.NotificationSettingsUpdateRequest;
 import com.example.emotion_storage.mypage.dto.response.MyPageOverviewResponse;
 import com.example.emotion_storage.mypage.dto.response.NotificationSettingsResponse;
+import com.example.emotion_storage.mypage.dto.response.PolicyResponse;
 import com.example.emotion_storage.mypage.dto.response.UserAccountInfoResponse;
 import com.example.emotion_storage.user.domain.User;
 import com.example.emotion_storage.user.repository.UserRepository;
@@ -83,5 +84,9 @@ public class MyPageService {
     private User findUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    public PolicyResponse getPolicy() {
+        return new PolicyResponse("정책"); // 약관 및 개인정보 처리 방침은 논의 필요
     }
 }

--- a/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
+++ b/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
@@ -8,8 +8,11 @@ import com.example.emotion_storage.mypage.dto.response.MyPageOverviewResponse;
 import com.example.emotion_storage.mypage.dto.response.NotificationSettingsResponse;
 import com.example.emotion_storage.mypage.dto.response.PolicyResponse;
 import com.example.emotion_storage.mypage.dto.response.UserAccountInfoResponse;
+import com.example.emotion_storage.user.auth.service.TokenService;
 import com.example.emotion_storage.user.domain.User;
 import com.example.emotion_storage.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MyPageService {
 
     private final UserRepository userRepository;
+    private final TokenService tokenService;
 
     @Transactional(readOnly = true)
     public MyPageOverviewResponse getMyPageOverview(Long userId) {
@@ -88,11 +92,19 @@ public class MyPageService {
     }
 
     @Transactional
-    public void withdrawUser(Long userId) {
+    public void withdrawUser(Long userId, HttpServletRequest request, HttpServletResponse response) {
         User user = findUserById(userId);
 
         log.info("회원 {}의 탈퇴 처리를 진행합니다.", userId);
         user.withdrawUser();
+
+        logout(userId, request, response);
+    }
+
+    @Transactional
+    public void logout(Long userId, HttpServletRequest request, HttpServletResponse response) {
+        log.info("회원 {}의 로그아웃을 진행합니다.", userId);
+        tokenService.revokeTokens(request, response, userId);
     }
 
     private User findUserById(Long userId) {

--- a/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
+++ b/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
@@ -3,11 +3,11 @@ package com.example.emotion_storage.mypage.service;
 import com.example.emotion_storage.global.exception.BaseException;
 import com.example.emotion_storage.global.exception.ErrorCode;
 import com.example.emotion_storage.mypage.dto.request.NicknameChangeRequest;
-import com.example.emotion_storage.mypage.dto.response.UserInfoResponse;
+import com.example.emotion_storage.mypage.dto.response.MyPageOverviewResponse;
+import com.example.emotion_storage.mypage.dto.response.UserAccountInfoResponse;
 import com.example.emotion_storage.user.domain.User;
 import com.example.emotion_storage.user.repository.UserRepository;
 import java.time.LocalDateTime;
-import java.time.Period;
 import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,18 +20,16 @@ public class MyPageService {
 
     private final UserRepository userRepository;
 
-    public UserInfoResponse getUserInfo(Long userId) {
+    public MyPageOverviewResponse getMyPageOverview(Long userId) {
         User user = findUserById(userId);
 
         log.info("사용자 {}의 닉네임, 가입 일수, 열쇠 개수를 조회합니다.", userId);
-        String nickname = user.getNickname();
-        long keys = user.getKeyCount();
 
         LocalDateTime signupDate = user.getCreatedAt();
         LocalDateTime now = LocalDateTime.now();
         long totalDays = ChronoUnit.DAYS.between(signupDate, now);
 
-        return new UserInfoResponse(nickname, totalDays, keys);
+        return new MyPageOverviewResponse(user.getNickname(), totalDays, user.getKeyCount());
     }
 
     public void changeUserNickname(NicknameChangeRequest request, Long userId) {
@@ -39,6 +37,15 @@ public class MyPageService {
 
         log.info("사용자 {}의 닉네임을 수정합니다.", userId);
         user.updateNickname(request.nickname());
+    }
+
+    public UserAccountInfoResponse getUserAccountInfo(Long userId) {
+        User user = findUserById(userId);
+
+        log.info("사용자 {}의 계정 정보를 조회합니다.", userId);
+        return new UserAccountInfoResponse(
+                user.getEmail(), user.getSocialType(), user.getGender(), user.getBirthday()
+        );
     }
 
     private User findUserById(Long userId) {

--- a/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
+++ b/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
@@ -2,6 +2,7 @@ package com.example.emotion_storage.mypage.service;
 
 import com.example.emotion_storage.global.exception.BaseException;
 import com.example.emotion_storage.global.exception.ErrorCode;
+import com.example.emotion_storage.mypage.dto.request.NicknameChangeRequest;
 import com.example.emotion_storage.mypage.dto.response.UserInfoResponse;
 import com.example.emotion_storage.user.domain.User;
 import com.example.emotion_storage.user.repository.UserRepository;
@@ -20,8 +21,7 @@ public class MyPageService {
     private final UserRepository userRepository;
 
     public UserInfoResponse getUserInfo(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
+        User user = findUserById(userId);
 
         log.info("사용자 {}의 닉네임, 가입 일수, 열쇠 개수를 조회합니다.", userId);
         String nickname = user.getNickname();
@@ -32,5 +32,17 @@ public class MyPageService {
         long totalDays = ChronoUnit.DAYS.between(signupDate, now);
 
         return new UserInfoResponse(nickname, totalDays, keys);
+    }
+
+    public void changeUserNickname(NicknameChangeRequest request, Long userId) {
+        User user = findUserById(userId);
+
+        log.info("사용자 {}의 닉네임을 수정합니다.", userId);
+        user.updateNickname(request.nickname());
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
+++ b/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
@@ -4,6 +4,7 @@ import com.example.emotion_storage.global.exception.BaseException;
 import com.example.emotion_storage.global.exception.ErrorCode;
 import com.example.emotion_storage.mypage.dto.request.NicknameChangeRequest;
 import com.example.emotion_storage.mypage.dto.response.MyPageOverviewResponse;
+import com.example.emotion_storage.mypage.dto.response.NotificationSettingsResponse;
 import com.example.emotion_storage.mypage.dto.response.UserAccountInfoResponse;
 import com.example.emotion_storage.user.domain.User;
 import com.example.emotion_storage.user.repository.UserRepository;
@@ -45,6 +46,20 @@ public class MyPageService {
         log.info("사용자 {}의 계정 정보를 조회합니다.", userId);
         return new UserAccountInfoResponse(
                 user.getEmail(), user.getSocialType(), user.getGender(), user.getBirthday()
+        );
+    }
+
+    public NotificationSettingsResponse getNotificationSettings(Long userId) {
+        User user = findUserById(userId);
+
+        log.info("사용자 {}의 알림 설정 상태 정보를 조회합니다.", userId);
+        return new NotificationSettingsResponse(
+                user.isAppPushNotify(),
+                user.isEmotionReminderNotify(),
+                user.getEmotionReminderDays(),
+                user.getEmotionReminderTime(),
+                user.isTimeCapsuleReportNotify(),
+                user.isMarketingInfoNotify()
         );
     }
 

--- a/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
+++ b/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
@@ -15,6 +15,7 @@ import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -23,6 +24,7 @@ public class MyPageService {
 
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
     public MyPageOverviewResponse getMyPageOverview(Long userId) {
         User user = findUserById(userId);
 
@@ -35,6 +37,7 @@ public class MyPageService {
         return new MyPageOverviewResponse(user.getNickname(), totalDays, user.getKeyCount());
     }
 
+    @Transactional
     public void changeUserNickname(NicknameChangeRequest request, Long userId) {
         User user = findUserById(userId);
 
@@ -42,6 +45,7 @@ public class MyPageService {
         user.updateNickname(request.nickname());
     }
 
+    @Transactional(readOnly = true)
     public UserAccountInfoResponse getUserAccountInfo(Long userId) {
         User user = findUserById(userId);
 
@@ -51,6 +55,7 @@ public class MyPageService {
         );
     }
 
+    @Transactional(readOnly = true)
     public NotificationSettingsResponse getNotificationSettings(Long userId) {
         User user = findUserById(userId);
 
@@ -65,6 +70,7 @@ public class MyPageService {
         );
     }
 
+    @Transactional
     public void updateNotificationSettings(NotificationSettingsUpdateRequest request, Long userId) {
         User user = findUserById(userId);
 
@@ -76,12 +82,21 @@ public class MyPageService {
         user.updateMarketingInfoNotify(request.marketingInfoNotify());
     }
 
+    @Transactional(readOnly = true)
+    public PolicyResponse getPolicy() {
+        return new PolicyResponse("정책"); // 약관 및 개인정보 처리 방침은 논의 필요
+    }
+
+    @Transactional
+    public void withdrawUser(Long userId) {
+        User user = findUserById(userId);
+
+        log.info("회원 {}의 탈퇴 처리를 진행합니다.", userId);
+        user.withdrawUser();
+    }
+
     private User findUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
-    }
-
-    public PolicyResponse getPolicy() {
-        return new PolicyResponse("정책"); // 약관 및 개인정보 처리 방침은 논의 필요
     }
 }

--- a/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
+++ b/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
@@ -71,12 +71,7 @@ public class MyPageService {
         log.info("사용자 {}의 알림 설정 상태를 업데이트합니다.", userId);
 
         user.updateAppPushNotify(request.appPushNotify());
-
-        user.updateEmotionReminderNotify(request.emotionReminderNotify());
-        user.getEmotionReminderDays().clear();
-        user.getEmotionReminderDays().addAll(request.emotionReminderDays());
-        user.updateEmotionReminderTime(request.emotionReminderTime());
-
+        user.updateEmotionReminder(request.emotionReminderNotify(), request.emotionReminderDays(), request.emotionReminderTime());
         user.updateTimeCapsuleReportNotify(request.timeCapsuleReportNotify());
         user.updateMarketingInfoNotify(request.marketingInfoNotify());
     }

--- a/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
+++ b/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
@@ -1,0 +1,36 @@
+package com.example.emotion_storage.mypage.service;
+
+import com.example.emotion_storage.global.exception.BaseException;
+import com.example.emotion_storage.global.exception.ErrorCode;
+import com.example.emotion_storage.mypage.dto.response.UserInfoResponse;
+import com.example.emotion_storage.user.domain.User;
+import com.example.emotion_storage.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+
+    public UserInfoResponse getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
+
+        log.info("사용자 {}의 닉네임, 가입 일수, 열쇠 개수를 조회합니다.", userId);
+        String nickname = user.getNickname();
+        long keys = user.getKeyCount();
+
+        LocalDateTime signupDate = user.getCreatedAt();
+        LocalDateTime now = LocalDateTime.now();
+        long totalDays = ChronoUnit.DAYS.between(signupDate, now);
+
+        return new UserInfoResponse(nickname, totalDays, keys);
+    }
+}

--- a/src/main/java/com/example/emotion_storage/user/auth/service/RedisService.java
+++ b/src/main/java/com/example/emotion_storage/user/auth/service/RedisService.java
@@ -23,6 +23,10 @@ public class RedisService {
         return "refresh:token:" + token;
     }
 
+    private String blacklistAccessTokenKey(String token) {
+        return "blacklist:access:" + token;
+    }
+
     public void saveRefreshToken(String userId, String refreshToken) {
         Duration ttl = Duration.ofDays(refreshTokenExpiration);
         redisTemplate.opsForValue().set(userKey(userId), refreshToken, ttl);
@@ -64,5 +68,15 @@ public class RedisService {
         }
         redisTemplate.delete(userKey(userId));
         saveRefreshToken(userId, newToken);
+    }
+
+    public void addAccessTokenToBlacklist(String accessToken, long remainingMillis) {
+        if (remainingMillis <= 0) return;
+        redisTemplate.opsForValue().set(
+                blacklistAccessTokenKey(accessToken), "true", Duration.ofMillis(remainingMillis));
+    }
+
+    public boolean isAccessTokenBlacklisted(String accessToken) {
+        return redisTemplate.hasKey(blacklistAccessTokenKey(accessToken));
     }
 }

--- a/src/main/java/com/example/emotion_storage/user/domain/User.java
+++ b/src/main/java/com/example/emotion_storage/user/domain/User.java
@@ -6,6 +6,7 @@ import com.example.emotion_storage.global.exception.BaseException;
 import com.example.emotion_storage.global.exception.ErrorCode;
 import com.example.emotion_storage.notification.domain.Notification;
 import com.example.emotion_storage.timecapsule.domain.TimeCapsule;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -173,11 +174,22 @@ public class User extends BaseTimeEntity {
         this.appPushNotify = appPushNotify;
     }
 
-    public void updateEmotionReminderNotify(boolean emotionReminderNotify) {
+    public void updateEmotionReminder(
+            boolean emotionReminderNotify, @Nullable Set<DayOfWeek> emotionReminderDays, @Nullable LocalTime emotionReminderTime
+    ) {
         this.emotionReminderNotify = emotionReminderNotify;
-    }
 
-    public void updateEmotionReminderTime(LocalTime emotionReminderTime) {
+        if (!emotionReminderNotify) {
+            this.emotionReminderDays = null;
+            this.emotionReminderTime = null;
+            return;
+        }
+
+        if (emotionReminderDays == null || emotionReminderDays.isEmpty()) throw new BaseException(ErrorCode.EMOTION_REMINDER_DAYS_REQUIRED);
+        if (emotionReminderTime == null) throw new BaseException(ErrorCode.EMOTION_REMINDER_TIME_REQUIRED);
+
+        this.emotionReminderDays.clear();
+        this.emotionReminderDays.addAll(emotionReminderDays);
         this.emotionReminderTime = emotionReminderTime;
     }
 

--- a/src/main/java/com/example/emotion_storage/user/domain/User.java
+++ b/src/main/java/com/example/emotion_storage/user/domain/User.java
@@ -19,10 +19,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -84,6 +88,27 @@ public class User extends BaseTimeEntity {
 
     @Column(nullable = false)
     private boolean isMarketingAgreed;
+
+    @Column(nullable = false)
+    private boolean appPushNotify;
+
+    @Column(nullable = false)
+    private boolean emotionReminderNotify;
+
+    @ElementCollection
+    @CollectionTable(name = "user_emotion_reminder_days", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "emotion_reminder_day")
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private Set<DayOfWeek> emotionReminderDays = new LinkedHashSet<>();
+
+    private LocalTime emotionReminderTime;
+
+    @Column(nullable = false)
+    private boolean timeCapsuleReportNotify;
+
+    @Column(nullable = false)
+    private boolean marketingInfoNotify;
 
     private LocalDateTime deletedAt;
 

--- a/src/main/java/com/example/emotion_storage/user/domain/User.java
+++ b/src/main/java/com/example/emotion_storage/user/domain/User.java
@@ -200,4 +200,8 @@ public class User extends BaseTimeEntity {
     public void updateMarketingInfoNotify(boolean marketingInfoNotify) {
         this.marketingInfoNotify = marketingInfoNotify;
     }
+
+    public void withdrawUser() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/example/emotion_storage/user/domain/User.java
+++ b/src/main/java/com/example/emotion_storage/user/domain/User.java
@@ -139,4 +139,8 @@ public class User extends BaseTimeEntity {
     public void initTicketCount() {
         this.ticketCount = 10L;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/example/emotion_storage/user/domain/User.java
+++ b/src/main/java/com/example/emotion_storage/user/domain/User.java
@@ -168,4 +168,24 @@ public class User extends BaseTimeEntity {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void updateAppPushNotify(boolean appPushNotify) {
+        this.appPushNotify = appPushNotify;
+    }
+
+    public void updateEmotionReminderNotify(boolean emotionReminderNotify) {
+        this.emotionReminderNotify = emotionReminderNotify;
+    }
+
+    public void updateEmotionReminderTime(LocalTime emotionReminderTime) {
+        this.emotionReminderTime = emotionReminderTime;
+    }
+
+    public void updateTimeCapsuleReportNotify(boolean timeCapsuleReportNotify) {
+        this.timeCapsuleReportNotify = timeCapsuleReportNotify;
+    }
+
+    public void updateMarketingInfoNotify(boolean marketingInfoNotify) {
+        this.marketingInfoNotify = marketingInfoNotify;
+    }
 }

--- a/src/main/java/com/example/emotion_storage/user/service/UserService.java
+++ b/src/main/java/com/example/emotion_storage/user/service/UserService.java
@@ -17,7 +17,10 @@ import com.example.emotion_storage.user.dto.request.GoogleLoginRequest;
 import com.example.emotion_storage.user.dto.request.GoogleSignUpRequest;
 import com.example.emotion_storage.user.dto.response.LoginResponse;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +28,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+    private static final int NOTIFICATION_DEFAULT_HOUR = 21;
+    private static final int NOTIFICATION_DEFAULT_MINUTE = 0;
 
     private final UserRepository userRepository;
     private final GoogleTokenVerifier googleTokenVerifier;
@@ -77,6 +83,13 @@ public class UserService {
                 .isMarketingAgreed(request.isMarketingAgreed())
                 .keyCount(5L)
                 .ticketCount(10L)
+                .appPushNotify(true)
+                .emotionReminderNotify(true)
+                .emotionReminderDays(Set.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY,
+                                DayOfWeek.THURSDAY,DayOfWeek.FRIDAY, DayOfWeek.SATURDAY, DayOfWeek.SUNDAY))
+                .emotionReminderTime(LocalTime.of(NOTIFICATION_DEFAULT_HOUR, NOTIFICATION_DEFAULT_MINUTE))
+                .timeCapsuleReportNotify(true)
+                .marketingInfoNotify(request.isMarketingAgreed())
                 .build();
 
         userRepository.save(user);
@@ -138,6 +151,13 @@ public class UserService {
                 .isMarketingAgreed(request.isMarketingAgreed())
                 .keyCount(5L)
                 .ticketCount(10L)
+                .appPushNotify(true)
+                .emotionReminderNotify(true)
+                .emotionReminderDays(Set.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY,
+                        DayOfWeek.THURSDAY,DayOfWeek.FRIDAY, DayOfWeek.SATURDAY, DayOfWeek.SUNDAY))
+                .emotionReminderTime(LocalTime.of(NOTIFICATION_DEFAULT_HOUR, NOTIFICATION_DEFAULT_MINUTE))
+                .timeCapsuleReportNotify(true)
+                .marketingInfoNotify(request.isMarketingAgreed())
                 .build();
 
         userRepository.save(user);


### PR DESCRIPTION
## ✨ 작업 내용
- 마이페이지 초기 화면
- 닉네임 재설정
- 계정 정보 확인
- 알림 설정 관련 기능
- 이용 약관 및 개인정보 처리방침 조회
- 회원 탈퇴
- 로그아웃

---

## 📝 적용 범위
- `/mypage`
- `/user`
- `/global`

---

## 📌 참고 사항
- 관련 이슈(#55)

## 💬 논의 사항
- 알림 설정 관련 속성은 User 도메인에 포함시킨 상태입니다!
- 알림 요일 관련 테이블은 앱 사용 목적과 같은 방식으로 구현한 상태입니다!
- 이용 약관 및 개인정보 처리방침을 어떻게 관리/반환할지 논의가 필요할 것 같습니다!