### PR TITLE
hotfix: 웹소켓 통신 시 게이지 응답 대기 시간 증가

### DIFF
--- a/src/main/java/com/example/emotion_storage/chat/service/WebSocketClientService.java
+++ b/src/main/java/com/example/emotion_storage/chat/service/WebSocketClientService.java
@@ -23,7 +23,7 @@ public class WebSocketClientService {
 
     // 상수 정의
     private static final int REQUEST_TIMEOUT_SECONDS = 30;
-    private static final int GAUGE_WAIT_MILLISECONDS = 1000;
+    private static final int GAUGE_WAIT_MILLISECONDS = 3000;
     private static final String MESSAGE_TYPE_CHAT_DELTA = "chat.delta";
     private static final String MESSAGE_TYPE_CHAT_END = "chat.end";
     private static final String MESSAGE_TYPE_CHAT_COMPLETED = "chat.complete";


### PR DESCRIPTION
## ✨ 작업 내용
- 웹소켓 통신 시 게이지 응답 대기 시간(`GAUGE_WAIT_MILLISECONDS`) 증가

---

## 📝 적용 범위
- `WebSocketClientService`
