### PR TITLE
feat: 계정 정보 조회 API에 닉네임 추가

### DIFF
--- a/src/main/java/com/example/emotion_storage/mypage/dto/response/UserAccountInfoResponse.java
+++ b/src/main/java/com/example/emotion_storage/mypage/dto/response/UserAccountInfoResponse.java
@@ -5,6 +5,7 @@ import com.example.emotion_storage.user.domain.SocialType;
 import java.time.LocalDate;
 
 public record UserAccountInfoResponse(
+        String nickname,
         String email,
         SocialType socialType,
         Gender gender,

--- a/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
+++ b/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
@@ -67,7 +67,7 @@ public class MyPageService {
 
         log.info("사용자 {}의 계정 정보를 조회합니다.", userId);
         return new UserAccountInfoResponse(
-                user.getEmail(), user.getSocialType(), user.getGender(), user.getBirthday()
+                user.getNickname(), user.getEmail(), user.getSocialType(), user.getGender(), user.getBirthday()
         );
     }
 


### PR DESCRIPTION
## ✨ 작업 내용
- 계정 정보 조회 시 닉네임도 반환하도록 응답 DTO에 닉네임 추가

---

## 📝 적용 범위
- `/mypage`

---

## 📌 참고 사항
- 관련 이슈(#84)