### PR TITLE
feat: 사용자 정보 상세 조회 응답 시에 가입 기간도 반환하도록 구현

### DIFF
--- a/src/main/java/com/example/emotion_storage/mypage/dto/response/UserAccountInfoResponse.java
+++ b/src/main/java/com/example/emotion_storage/mypage/dto/response/UserAccountInfoResponse.java
@@ -9,5 +9,6 @@ public record UserAccountInfoResponse(
         String email,
         SocialType socialType,
         Gender gender,
-        LocalDate birthday
+        LocalDate birthday,
+        long days
 ) {}

--- a/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
+++ b/src/main/java/com/example/emotion_storage/mypage/service/MyPageService.java
@@ -36,11 +36,7 @@ public class MyPageService {
         User user = findUserById(userId);
 
         log.info("사용자 {}의 닉네임, 가입 일수, 열쇠 개수를 조회합니다.", userId);
-
-        LocalDate signupDate = user.getCreatedAt().toLocalDate();
-        LocalDate today = LocalDate.now();
-        long totalDays = ChronoUnit.DAYS.between(signupDate, today) + 1; // 가입한 순간부터 1일로 계산
-
+        long totalDays = calculateSignUpDuration(user);
         return new MyPageOverviewResponse(user.getNickname(), totalDays, user.getKeyCount());
     }
 
@@ -66,9 +62,16 @@ public class MyPageService {
         User user = findUserById(userId);
 
         log.info("사용자 {}의 계정 정보를 조회합니다.", userId);
+        long days = calculateSignUpDuration(user);
         return new UserAccountInfoResponse(
-                user.getNickname(), user.getEmail(), user.getSocialType(), user.getGender(), user.getBirthday()
+                user.getNickname(), user.getEmail(), user.getSocialType(), user.getGender(), user.getBirthday(), days
         );
+    }
+
+    private long calculateSignUpDuration(User user) {
+        LocalDate signupDate = user.getCreatedAt().toLocalDate();
+        LocalDate today = LocalDate.now();
+        return ChronoUnit.DAYS.between(signupDate, today) + 1; // 가입한 순간부터 1일로 계산
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/example/emotion_storage/mypage/controller/MyPageControllerTest.java
+++ b/src/test/java/com/example/emotion_storage/mypage/controller/MyPageControllerTest.java
@@ -121,7 +121,7 @@ public class MyPageControllerTest {
     void 사용자_계정_정보_조회에_성공한다() throws Exception {
         // given
         UserAccountInfoResponse response = new UserAccountInfoResponse(
-                "test@example.com", SocialType.GOOGLE, Gender.MALE, LocalDate.of(2000, 1, 1)
+                "MOOI", "test@example.com", SocialType.GOOGLE, Gender.MALE, LocalDate.of(2000, 1, 1), 200
         );
 
         given(myPageService.getUserAccountInfo(anyLong()))
@@ -132,10 +132,12 @@ public class MyPageControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.message").value(SuccessMessage.GET_USER_ACCOUNT_INFO_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.nickname").value("MOOI"))
                 .andExpect(jsonPath("$.data.email").value("test@example.com"))
                 .andExpect(jsonPath("$.data.socialType").value("GOOGLE"))
                 .andExpect(jsonPath("$.data.gender").value("MALE"))
-                .andExpect(jsonPath("$.data.birthday").value("2000-01-01"));
+                .andExpect(jsonPath("$.data.birthday").value("2000-01-01"))
+                .andExpect(jsonPath("$.data.days").value(200));
     }
 
     @Test


### PR DESCRIPTION
## ✨ 작업 내용
- 사용자 상세 정보 조회 API 응답에 가입 기간 추가

---

## 📝 적용 범위
- `/mypage`

---

## 📌 참고 사항
- 관련 이슈(#89)