### PR TITLE
hotfix: 채팅방 입장 시 채팅방 아이디를 반환할 때 발생했던 오류 수정

### DIFF
--- a/src/main/java/com/example/emotion_storage/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/emotion_storage/chat/repository/ChatRoomRepository.java
@@ -21,7 +21,9 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "AND (cr.createdAt < :createdAt or (cr.createdAt = :createdAt AND cr.id < :currentChatRoomId)) " +
             "ORDER BY cr.createdAt DESC, cr.id DESC"
     )
-    Optional<ChatRoom> findPrevRoom(Long userId, LocalDateTime createdAt, Long currentChatRoomId);
+    Optional<ChatRoom> findPrevRoom(
+            @Param("userId") Long userId, @Param("createdAt") LocalDateTime createdAt,
+            @Param("currentChatRoomId") Long currentChatRoomId, Pageable pageable);
 
     @Query(
             "SELECT cr FROM ChatRoom cr " +

--- a/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
+++ b/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
@@ -101,7 +101,7 @@ public class ChatService {
     private boolean isFirstChatRoomOfDay(ChatRoom currentRoom) {
         log.info("현재 채팅방 {}의 바로 직전 채팅방을 조회합니다.", currentRoom.getId());
         ChatRoom prevRoom = chatRoomRepository.findPrevRoom(
-                currentRoom.getUser().getId(), currentRoom.getCreatedAt(), currentRoom.getId()
+                currentRoom.getUser().getId(), currentRoom.getCreatedAt(), currentRoom.getId(), PageRequest.of(0, 1)
         ).orElse(null);
 
         if (prevRoom == null) {


### PR DESCRIPTION
## ✨ 작업 내용
-  현재 채팅방 이전의 채팅방을 조회할 때 모든 채팅방을 조회하던 부분을 확인하여 한 개의 채팅방만 조회하도록 수정

---

## 📝 적용 범위
- `/chat`

---

## 📌 참고 사항
- 관련 이슈(#95)