### PR TITLE
hotfix: Read timeout 증가를 통해 AI 서버 응답 시간을 확보하도록 수정

### DIFF
--- a/src/main/java/com/example/emotion_storage/global/config/rest/RestTemplateConfig.java
+++ b/src/main/java/com/example/emotion_storage/global/config/rest/RestTemplateConfig.java
@@ -1,5 +1,6 @@
 package com.example.emotion_storage.global.config.rest;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -8,11 +9,17 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class RestTemplateConfig {
 
+    @Value("${rest-template.connect-timeout:5000}")
+    private int connectTimeout;
+
+    @Value("${rest-template.read-timeout:120000}")
+    private int readTimeout;
+
     @Bean
     public RestTemplate restTemplate() {
         HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
-        factory.setConnectTimeout(5000);
-        factory.setReadTimeout(5000);
+        factory.setConnectTimeout(connectTimeout);
+        factory.setReadTimeout(readTimeout);
         return new RestTemplate(factory);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,7 @@ spring:
       pool:
         size: 5
       thread-name-prefix: "scheduled-task-"
+
+rest-template:
+  connect-timeout: 5000
+  read-timeout: 120000


### PR DESCRIPTION
## ✨ 작업 내용
- Read timeout 기존 5초에서 12초로 증가

---

## 📝 적용 범위
- `applcation.yml`, `RestTemplateConfig.java`
