### PR TITLE
chore: 채팅 응답을 문장 별로 나누어 반환하도록 수정

### DIFF
--- a/src/main/java/com/example/emotion_storage/chat/controller/ChatController.java
+++ b/src/main/java/com/example/emotion_storage/chat/controller/ChatController.java
@@ -3,7 +3,6 @@ package com.example.emotion_storage.chat.controller;
 import com.example.emotion_storage.chat.dto.request.ChatRequest;
 import com.example.emotion_storage.chat.dto.response.AiChatResponse;
 import com.example.emotion_storage.chat.dto.response.ChatRoomTempSaveResponse;
-import com.example.emotion_storage.chat.dto.response.RoomWithChatsDto;
 import com.example.emotion_storage.chat.dto.response.SingleRoomSliceResponse;
 import com.example.emotion_storage.chat.service.ChatService;
 import com.example.emotion_storage.global.api.ApiResponse;


### PR DESCRIPTION
## ✨ 작업 내용
- 채팅 응답 문장 별로 반환

**문장 별 응답: `type: chat.delta`**
```
{"content":"헉, 붕어빵 정말 맛있지!",
"sender":"MOOI","timestamp":"2025-11-19T22:27:18.457917","gauge":null,"room_id":50,"session_id":"session-1-50","message_type":"chat.delta"} 
{"content":"따뜻하고 달콤한 팥이 가득한 그 맛, 상상만 해도 군침이 돌어.",
"sender":"MOOI","timestamp":"2025-11-19T22:27:18.459604","gauge":null,"room_id":50,"session_id":"session-1-50","message_type":"chat.delta"}
{"content":"근데 가격이 그렇게 올랐다니… 정말 세월이 느껴지는 것 같아.",
"sender":"MOOI","timestamp":"2025-11-19T22:27:18.462336","gauge":null,"room_id":50,"session_id":"session-1-50","message_type":"chat.delta"}
{"content":"그런 변화를 느끼니까 좀 씁쓸할 수 있겠네.",
"sender":"MOOI","timestamp":"2025-11-19T22:27:18.463692","gauge":null,"room_id":50,"session_id":"session-1-50","message_type":"chat.delta"} 
{"content":"그럴 때 어떤 기분이 드는지 궁금해!",
"sender":"MOOI","timestamp":"2025-11-19T22:27:18.46442","gauge":null,"room_id":50,"session_id":"session-1-50","message_type":"chat.delta"} 
```

**전체(최종) 응답: `type: chat.complete`**
```
{"content":"헉, 붕어빵 정말 맛있지!따뜻하고 달콤한 팥이 가득한 그 맛, 상상만 해도 군침이 돌어.근데 가격이 그렇게 올랐다니…
정말 세월이 느껴지는 것 같아.그런 변화를 느끼니까 좀 씁쓸할 수 있겠네.그럴 때 어떤 기분이 드는지 궁금해!",
"sender":"MOOI",
"timestamp":"2025-11-19T22:27:18.489374",
"gauge":{"summary":"대화는 2턴으로 이루어졌으며, 사용자에게선 긍정적인 감정(맛있음)과 부정적인 감정(가격 상승) 표현이 있었습니다. 
사건(붕어빵 가격과 관련된 경험)이 구체적으로 언급되었으나, 감정 변화는 명확하지 않았습니다. 
감정 표현과 다양성이 존재하지만, 변화를 통한 깊이 있는 감정 정보가 부족해 타임캡슐 생성에는 제한적입니다.",
"gauge_score":70,
"turn_count_score":1,
"emotion_expression_score":15,
"emotion_diversity_score":10,
"event_reference_score":20,
"emotion_change_score":0},
"room_id":50,
"session_id":"session-1-50",
"message_type":"chat.complete"}
```

---

## 📝 적용 범위
- `ChatController.java`, `ChatService.java`, `WebSocketClientService.java`

---

## 📌 참고 사항
스트리밍 전송 적용

close #102 