### PR TITLE
hotfix: 채팅방 생성 시 유저 누락 부분 수정

### DIFF
--- a/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
+++ b/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
@@ -89,6 +89,7 @@ public class ChatService {
 
         ChatRoom newRoom = chatRoomRepository.save(
                 ChatRoom.builder()
+                        .user(user)
                         .isEnded(false)
                         .isTempSave(false)
                         .build()


### PR DESCRIPTION
## ✨ 작업 내용
- 채팅방 생성 시에 유저를 누락해서 500 에러가 발생했던 부분 수정

---

## 📝 적용 범위
- `/chat`

---

## 📌 참고 사항
- 관련 이슈 번호, 리뷰 시 유의사항 등을 적어주세요.