### PR TITLE
feat: 회원 탈퇴 후 즉시 재가입 가능한 구조로 변경

### DIFF
--- a/src/main/java/com/example/emotion_storage/user/domain/User.java
+++ b/src/main/java/com/example/emotion_storage/user/domain/User.java
@@ -33,6 +33,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name = "users")
@@ -40,6 +42,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@SQLDelete(sql = "UPDATE users SET deleted_at = NOW() WHERE user_id = ?")
+@Where(clause = "deleted_at IS NULL")
 public class User extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/example/emotion_storage/user/service/UserService.java
+++ b/src/main/java/com/example/emotion_storage/user/service/UserService.java
@@ -82,6 +82,7 @@ public class UserService {
                 .emotionReminderTime(LocalTime.of(NOTIFICATION_DEFAULT_HOUR, NOTIFICATION_DEFAULT_MINUTE))
                 .timeCapsuleReportNotify(true)
                 .marketingInfoNotify(request.isMarketingAgreed())
+                .deletedAt(null)
                 .build();
 
         userRepository.save(user);
@@ -130,6 +131,7 @@ public class UserService {
                 .emotionReminderTime(LocalTime.of(NOTIFICATION_DEFAULT_HOUR, NOTIFICATION_DEFAULT_MINUTE))
                 .timeCapsuleReportNotify(true)
                 .marketingInfoNotify(request.isMarketingAgreed())
+                .deletedAt(null)
                 .build();
 
         userRepository.save(user);


### PR DESCRIPTION
## ✨ 작업 내용
- 회원 탈퇴 후 즉시 재가입 가능한 구조로 변경

---

## 📝 적용 범위
- `/user`

---

## 📌 참고 사항
- 관련 이슈(Closed #109)