### PR TITLE
fix: 회원 재가입 시 이메일 중복으로 재가입이 되지 않았던 오류 수정

### DIFF
--- a/src/main/java/com/example/emotion_storage/user/domain/User.java
+++ b/src/main/java/com/example/emotion_storage/user/domain/User.java
@@ -20,6 +20,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -37,7 +38,15 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 @Entity
-@Table(name = "users")
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_users_email_deleted_at",
+                        columnNames = {"email", "deleted_at"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -58,7 +67,7 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String socialId;
 
-    @Column(unique = true)
+    @Column(nullable = false)
     private String email;
 
     private String profileImageUrl;


### PR DESCRIPTION
## ✨ 작업 내용
- 회원 재가입 시 이메일 중복으로 재가입이 되지 않았던 오류 수정
- 회원 탈퇴시 soft delete로 설정되어 있었고 email에 unique 제약 조건이 존재해 재가입시 이메일 중복으로 재가입이 되지 않았던 상황
- 이메일 중복 제약 조건을 이메일과 deletedAt으로 설정

---

## 📝 적용 범위
- `/user`

---

## 📌 참고 사항
- 관련 이슈(Closed #111)