### PR TITLE
fix: AI 채팅 메시지가 문장 단위로 분리되지 않던 문제 수정

### DIFF
--- a/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
+++ b/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
@@ -59,7 +59,7 @@ public class ChatService {
     private static final String SESSION_ID_FORMAT = "session-%d-%d";
 
     // AI 메시지 분리 상수
-    private static final String AI_SENTENCE_SPLIT_REGEX = "(?<=[.!?！？])\\s+";
+    private static final String AI_SENTENCE_SPLIT_REGEX = "(?<=[.!?！？])";
 
     private final SimpMessagingTemplate messagingTemplate;
     private final UserRepository userRepository;


### PR DESCRIPTION
## ✨ 작업 내용
- 정규식에서 문장부호 사이의 띄어쓰기가 없어서 문장이 분리가 되지 않던 오류 해결

---

## 📝 적용 범위
- `/chat`

---

## 📌 참고 사항
- 관련 이슈(Closed #121)