### PR TITLE
refactor: AI 채팅 응답 분리 시 clientId로 UI 식별자 분리

### DIFF
--- a/src/main/java/com/example/emotion_storage/chat/dto/response/ChatDto.java
+++ b/src/main/java/com/example/emotion_storage/chat/dto/response/ChatDto.java
@@ -5,11 +5,14 @@ import java.time.LocalDateTime;
 
 public record ChatDto(
         Long id,
+        String clientId,
         String sender,
         String message,
         LocalDateTime chatTime
 ) {
     public static ChatDto from(Chat chat) {
-        return new ChatDto(chat.getId(), chat.getSender().name(), chat.getMessage(), chat.getChatTime());
+        return new ChatDto(
+                chat.getId(), chat.getId().toString(), chat.getSender().name(), chat.getMessage(), chat.getChatTime()
+        );
     }
 }

--- a/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
+++ b/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
@@ -408,7 +408,8 @@ public class ChatService {
             if (trimmed.isEmpty()) continue;
 
             chats.add(new ChatDto(
-                    chat.getId(), chat.getSender().name(), trimmed, baseTime.plusNanos(i++)
+                    chat.getId(), chat.getId().toString() + "-" + i,
+                    chat.getSender().name(), trimmed, baseTime.plusNanos(i++)
             ));
         }
         return chats;


### PR DESCRIPTION
## ✨ 작업 내용
- AI 채팅 응답 분리 시 clientId로 UI 식별자 분리

---

## 📝 적용 범위
- `/chat`

---

## 📌 참고 사항
- 관련 이슈 번호, 리뷰 시 유의사항 등을 적어주세요.