### PR TITLE
fix: 일일리포트 및 타임캡슐 감정 라벨 이모지 공백 정규화

### DIFF
--- a/src/main/java/com/example/emotion_storage/global/util/LabelNormalizer.java
+++ b/src/main/java/com/example/emotion_storage/global/util/LabelNormalizer.java
@@ -1,0 +1,13 @@
+package com.example.emotion_storage.global.util;
+
+public final class LabelNormalizer {
+    private LabelNormalizer() {
+    }
+
+    public static String emojiSpace(String label) {
+        if (label == null || label.isBlank()) {
+            return label;
+        }
+        return label.replaceAll("([\\p{So}])([가-힣])", "$1 $2");
+    }
+}

--- a/src/main/java/com/example/emotion_storage/report/dto/response/DailyReportDetailResponse.java
+++ b/src/main/java/com/example/emotion_storage/report/dto/response/DailyReportDetailResponse.java
@@ -1,5 +1,6 @@
 package com.example.emotion_storage.report.dto.response;
 
+import com.example.emotion_storage.global.util.LabelNormalizer;
 import com.example.emotion_storage.report.domain.EmotionVariation;
 import com.example.emotion_storage.report.domain.Keyword;
 import com.example.emotion_storage.report.domain.Report;
@@ -50,7 +51,7 @@ public class DailyReportDetailResponse {
                 .emotionChanges(report.getEmotionVariations().stream()
                         .map(emotionVariation -> EmotionChangeDto.builder()
                                 .time(formatTime(emotionVariation.getTime()))
-                                .label(emotionVariation.getLabel())
+                                .label(LabelNormalizer.emojiSpace(emotionVariation.getLabel()))
                                 .build())
                         .collect(Collectors.toList()))
                 .build();

--- a/src/main/java/com/example/emotion_storage/timecapsule/dto/EmotionDetailDto.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/dto/EmotionDetailDto.java
@@ -1,6 +1,15 @@
 package com.example.emotion_storage.timecapsule.dto;
 
+import com.example.emotion_storage.global.util.LabelNormalizer;
+
 public record EmotionDetailDto(
         String label,
         int ratio
-) {}
+) {
+    public static EmotionDetailDto of(String label, int ratio) {
+        return new EmotionDetailDto(
+                LabelNormalizer.emojiSpace(label),
+                ratio
+        );
+    }
+}

--- a/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/service/TimeCapsuleService.java
@@ -207,7 +207,7 @@ public class TimeCapsuleService {
                         } catch (NumberFormatException ignored) {}
                         label = line.substring(0, matcher.start()).trim();
                     }
-                    return new EmotionDetailDto(label, ratio);
+                    return EmotionDetailDto.of(label, ratio);
                 })
                 .filter(e -> !e.label().isEmpty())
                 .toList();


### PR DESCRIPTION
## ✨ 작업 내용
- 일일리포트 및 타임캡슐 감정 라벨 이모지 공백 정규화

---

## 📝 적용 범위
- `/global/util`
- `/timecapsule`
- `/report`

---

## 📌 참고 사항
- 관련 이슈 번호(Closed #120)