### PR TITLE
feat: 사용자 기준 최신 일일 리포트 id 조회 로직 추가

### DIFF
--- a/src/main/java/com/example/emotion_storage/home/dto/response/NewDailyReportResponse.java
+++ b/src/main/java/com/example/emotion_storage/home/dto/response/NewDailyReportResponse.java
@@ -9,4 +9,5 @@ public class NewDailyReportResponse {
     
     private final boolean hasNewReport;
     private final int count;
+    private final Long reportId;
 }

--- a/src/main/java/com/example/emotion_storage/home/service/HomeService.java
+++ b/src/main/java/com/example/emotion_storage/home/service/HomeService.java
@@ -124,10 +124,15 @@ public class HomeService {
         // 미확인 일일리포트 개수 조회
         Long unopenedReportCount = reportRepository.countUnopenedReportsByUserId(userId);
         boolean hasNewReport = unopenedReportCount > 0;
+
+        // 최근 일일리포트 아이디 조회
+        Long currentReportId = reportRepository.findLatestReportIdByUserId(userId)
+                .orElse(null);
         
         NewDailyReportResponse response = NewDailyReportResponse.builder()
                 .hasNewReport(hasNewReport)
                 .count(unopenedReportCount.intValue())
+                .reportId(currentReportId)
                 .build();
         
         log.info("사용자 새로운 일일리포트 상태 조회 완료 - userId: {}, hasNewReport: {}, count: {}", 

--- a/src/main/java/com/example/emotion_storage/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/emotion_storage/report/repository/ReportRepository.java
@@ -1,6 +1,8 @@
 package com.example.emotion_storage.report.repository;
 
 import com.example.emotion_storage.report.domain.Report;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,4 +23,17 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
            "JOIN r.timeCapsules tc " +
            "WHERE tc.user.id = :userId AND r.historyDate = :historyDate")
     Optional<Report> findByUserIdAndHistoryDate(@Param("userId") Long userId, @Param("historyDate") LocalDate historyDate);
+
+    @Query("""
+        select distinct r.id
+        from Report r
+        join r.timeCapsules tc
+        where tc.user.id = :userId
+        order by r.historyDate desc
+    """)
+    List<Long> findLatestReportIdsByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    default Optional<Long> findLatestReportIdByUserId(Long userId) {
+        return findLatestReportIdsByUserId(userId, Pageable.ofSize(1)).stream().findFirst();
+    }
 }


### PR DESCRIPTION
## ✨ 작업 내용
- 사용자 기준 최신 일일 리포트 id 조회 로직 추가

---

## 📝 적용 범위
- `/report`
- `/home`

---

## 📌 참고 사항
- 관련 이슈(Closed #131)