### PR TITLE
feat: 일일리포트 상세 조회 시 열람 여부 및 historyDate를 반환하도록 추가

### DIFF
--- a/src/main/java/com/example/emotion_storage/report/dto/response/DailyReportDetailResponse.java
+++ b/src/main/java/com/example/emotion_storage/report/dto/response/DailyReportDetailResponse.java
@@ -3,6 +3,7 @@ package com.example.emotion_storage.report.dto.response;
 import com.example.emotion_storage.global.util.LabelNormalizer;
 import com.example.emotion_storage.report.domain.Keyword;
 import com.example.emotion_storage.report.domain.Report;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +19,8 @@ import java.util.stream.Collectors;
 public class DailyReportDetailResponse {
 
     private Long id;
+    private boolean isOpened;
+    private LocalDate historyDate;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private List<String> summaries;
@@ -38,6 +41,8 @@ public class DailyReportDetailResponse {
     public static DailyReportDetailResponse from(Report report) {
         return DailyReportDetailResponse.builder()
                 .id(report.getId())
+                .isOpened(report.getIsOpened())
+                .historyDate(report.getHistoryDate())
                 .createdAt(report.getCreatedAt())
                 .updatedAt(report.getUpdatedAt())
                 .summaries(List.of(report.getTodaySummary()))


### PR DESCRIPTION
## ✨ 작업 내용
- 일일리포트 상세 조회 시 열람 여부 및 historyDate를 반환하도록 추가

---

## 📝 적용 범위
- `/report`

---

## 📌 참고 사항
- 관련 이슈 번호, 리뷰 시 유의사항 등을 적어주세요.