### PR TITLE
refactor: 홈 통합 API에서 새로운 타임캡슐 도착 기간 범위를 최근 3주로 변경

### DIFF
--- a/src/main/java/com/example/emotion_storage/home/service/HomeService.java
+++ b/src/main/java/com/example/emotion_storage/home/service/HomeService.java
@@ -13,6 +13,7 @@ import com.example.emotion_storage.report.repository.ReportRepository;
 import com.example.emotion_storage.timecapsule.repository.TimeCapsuleRepository;
 import com.example.emotion_storage.user.domain.User;
 import com.example.emotion_storage.user.repository.UserRepository;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -100,9 +101,12 @@ public class HomeService {
         
         // 사용자 존재 여부 확인
         findUserById(userId);
-        
+
+        LocalDateTime end = LocalDateTime.now();
+        LocalDateTime start = end.minusWeeks(3);
+
         // 미확인 타임캡슐 개수 조회
-        Long unopenedCount = timeCapsuleRepository.countUnopenedTimeCapsulesByUserId(userId);
+        Long unopenedCount = timeCapsuleRepository.countUnopenedArrivedTimeCapsulesInRange(userId, start, end);
         boolean hasNewCapsule = unopenedCount > 0;
         
         NewTimeCapsuleResponse response = NewTimeCapsuleResponse.builder()

--- a/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
@@ -24,6 +24,22 @@ public interface TimeCapsuleRepository extends JpaRepository<TimeCapsule, Long> 
     @Query("SELECT COUNT(tc) FROM TimeCapsule tc WHERE tc.user.id = :userId AND tc.isOpened = false AND tc.deletedAt IS NULL")
     Long countUnopenedTimeCapsulesByUserId(@Param("userId") Long userId);
 
+    @Query("""
+        SELECT COUNT(tc)
+        FROM TimeCapsule tc
+        WHERE tc.user.id = :userId
+          AND tc.deletedAt IS NULL
+          AND tc.isTempSave = false
+          AND tc.isOpened = false
+          AND tc.openedAt >= :start
+          AND tc.openedAt <= :end
+    """)
+    Long countUnopenedArrivedTimeCapsulesInRange(
+            @Param("userId") Long userId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
+
     @Query("SELECT DISTINCT CAST(tc.historyDate AS DATE) from TimeCapsule tc "
             + "WHERE tc.user.id = :userId AND tc.historyDate >= :start AND tc.historyDate < :end AND tc.deletedAt IS NULL "
             + "ORDER BY CAST(tc.historyDate AS DATE)")


### PR DESCRIPTION
## ✨ 작업 내용
- 홈 통합 API에서 새로운 타임캡슐 도착 기간 범위를 최근 3주로 변경

---

## 📝 적용 범위
- `/home`

---

## 📌 참고 사항
- 관련 이슈(Closed #141)