### PR TITLE
refactor: 일일 리포트 summaries 응답 형식 개선

### DIFF
--- a/src/main/java/com/example/emotion_storage/report/dto/response/DailyReportDetailResponse.java
+++ b/src/main/java/com/example/emotion_storage/report/dto/response/DailyReportDetailResponse.java
@@ -4,6 +4,7 @@ import com.example.emotion_storage.global.util.LabelNormalizer;
 import com.example.emotion_storage.report.domain.Keyword;
 import com.example.emotion_storage.report.domain.Report;
 import java.time.LocalDate;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,23 +46,50 @@ public class DailyReportDetailResponse {
                 .historyDate(report.getHistoryDate())
                 .createdAt(report.getCreatedAt())
                 .updatedAt(report.getUpdatedAt())
-                .summaries(List.of(report.getTodaySummary()))
-                .keywords(report.getKeywords().stream()
-                        .map(Keyword::getKeyword)
-                        .collect(Collectors.toList()))
+                .summaries(toSummaries(report.getTodaySummary()))
+                .keywords(toKeywords(report))
                 .stressIndex(report.getStressIndex())
                 .happinessIndex(report.getHappinessIndex())
                 .emotionSummary(report.getEmotionSummary())
-                .emotionChanges(report.getEmotionVariations().stream()
-                        .map(emotionVariation -> EmotionChangeDto.builder()
-                                .time(formatTime(emotionVariation.getTime()))
-                                .label(LabelNormalizer.emojiSpace(emotionVariation.getLabel()))
-                                .build())
-                        .collect(Collectors.toList()))
+                .emotionChanges(toEmotionChanges(report))
                 .build();
     }
 
     private static String formatTime(LocalDateTime dateTime) {
         return dateTime.format(DateTimeFormatter.ofPattern("HH:mm"));
+    }
+
+    private static List<String> toKeywords(Report report) {
+        if (report.getKeywords() == null || report.getKeywords().isEmpty()) {
+            return List.of();
+        }
+
+        return report.getKeywords().stream()
+                .map(Keyword::getKeyword)
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> toSummaries(String todaySummary) {
+        if (todaySummary == null || todaySummary.isBlank()) {
+            return List.of();
+        }
+
+        return Arrays.stream(todaySummary.split("\\n"))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    private static List<EmotionChangeDto> toEmotionChanges(Report report) {
+        if (report.getEmotionVariations() == null || report.getEmotionVariations().isEmpty()) {
+            return List.of();
+        }
+
+        return report.getEmotionVariations().stream()
+                .map(v -> EmotionChangeDto.builder()
+                        .time(formatTime(v.getTime()))
+                        .label(LabelNormalizer.emojiSpace(v.getLabel()))
+                        .build())
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
- 오늘 요약 문자열을 줄바꿈 기준으로 분리하여 배열로 응답하도록 수정

---

## 📝 적용 범위
- `/report`

---

## 📌 참고 사항
- 관련 이슈(Closed #144)