### PR TITLE
feat: 홈 정보 통합 API 조회 시 닉네임도 반환하도록 구현

### DIFF
--- a/src/main/java/com/example/emotion_storage/home/dto/response/HomeInfoResponse.java
+++ b/src/main/java/com/example/emotion_storage/home/dto/response/HomeInfoResponse.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 @Builder
 public class HomeInfoResponse {
-    
+
+    private final String userName;
     private final Long remainingTickets;
     private final Long dailyLimit;
     private final Long keyCount;

--- a/src/main/java/com/example/emotion_storage/home/service/HomeService.java
+++ b/src/main/java/com/example/emotion_storage/home/service/HomeService.java
@@ -36,7 +36,7 @@ public class HomeService {
         log.info("사용자 홈 정보 조회 요청 - userId: {}", userId);
 
         // 사용자 존재 여부 확인
-        findUserById(userId);
+        User user = findUserById(userId);
 
         // 각종 정보 조회
         TicketStatusResponse ticketStatus = getTicketStatus(userId);
@@ -46,6 +46,7 @@ public class HomeService {
         NewDailyReportResponse reportStatus = getNewDailyReportStatus(userId);
 
         HomeInfoResponse response = HomeInfoResponse.builder()
+                .userName(user.getNickname())
                 .remainingTickets(ticketStatus.getRemainingTickets())
                 .dailyLimit(ticketStatus.getDailyLimit())
                 .keyCount(keyCount.getKeyCount())


### PR DESCRIPTION
## ✨ 작업 내용
- 홈 정보 통합 API 조회 시 닉네임도 반환하도록 구현

---

## 📝 적용 범위
- `/home`

---

## 📌 참고 사항
- 관련 이슈(Closed #150)