### PR TITLE
fix: 마이페이지 API를 인증 사용자 기준으로 수정

### DIFF
--- a/src/main/java/com/example/emotion_storage/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/emotion_storage/global/config/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                 .headers(h -> h.frameOptions(FrameOptionsConfig::sameOrigin)) // H2 콘솔 접근 시 iframe 사용 허용 (동일 출처만 허용하여 보안 유지)
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/mypage", "/api/v1/mypage/**").authenticated() // 마이페이지 조회 시 1L에 해당하는 유저 정보가 반환되는 문제 확인을 위함
                         // 개발 편의성을 위한 PERMIT ALL 설정
 //                        .requestMatchers("/auth/session").authenticated()
 //                        .requestMatchers("/auth/**",

--- a/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
+++ b/src/main/java/com/example/emotion_storage/mypage/controller/MyPageController.java
@@ -40,7 +40,7 @@ public class MyPageController {
     public ResponseEntity<ApiResponse<MyPageOverviewResponse>> getMyPageOverview(
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal
     ) {
-        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        Long userId = userPrincipal.getId();
         log.info("사용자 {}의 마이페이지 내 정보 조회를 요청받았습니다.", userId);
         MyPageOverviewResponse response = myPageService.getMyPageOverview(userId);
         return ResponseEntity.ok(ApiResponse.success(
@@ -53,7 +53,7 @@ public class MyPageController {
             @RequestBody NicknameChangeRequest request,
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal
     ) {
-        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        Long userId = userPrincipal.getId();
         log.info("사용자 {}의 닉네임 수정을 요청받았습니다.", userId);
         myPageService.changeUserNickname(request, userId);
         return ResponseEntity.ok(ApiResponse.success(
@@ -67,7 +67,7 @@ public class MyPageController {
     public ResponseEntity<ApiResponse<UserKeyCountResponse>> getUserKeyCount(
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal
     ) {
-        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        Long userId = userPrincipal.getId();
         log.info("사용자 {}의 열쇠 개수 조회를 요청받았습니다.", userId);
         UserKeyCountResponse response = myPageService.getUserKeyCount(userId);
         return ResponseEntity.ok(ApiResponse.success(
@@ -79,7 +79,7 @@ public class MyPageController {
     public ResponseEntity<ApiResponse<UserAccountInfoResponse>> getUserAccountInfo(
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal
     ) {
-        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        Long userId = userPrincipal.getId();
         log.info("사용자 {}의 계정 정보 조회를 요청받았습니다.", userId);
         UserAccountInfoResponse response = myPageService.getUserAccountInfo(userId);
         return ResponseEntity.ok(ApiResponse.success(
@@ -91,7 +91,7 @@ public class MyPageController {
     public ResponseEntity<ApiResponse<NotificationSettingsResponse>> getNotificationSettings(
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal
     ) {
-        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        Long userId = userPrincipal.getId();
         log.info("사용자 {}의 알림설정 상태 정보 조회를 요청받았습니다.", userId);
         NotificationSettingsResponse response = myPageService.getNotificationSettings(userId);
         return ResponseEntity.ok(ApiResponse.success(
@@ -104,7 +104,7 @@ public class MyPageController {
             @RequestBody NotificationSettingsUpdateRequest request,
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal
     ) {
-        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        Long userId = userPrincipal.getId();
         log.info("사용자 {}의 알림설정 상태 업데이트를 요청받았습니다.", userId);
         myPageService.updateNotificationSettings(request, userId);
         return ResponseEntity.ok(ApiResponse.success(
@@ -119,7 +119,7 @@ public class MyPageController {
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
             HttpServletRequest request, HttpServletResponse response
     ) {
-        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        Long userId = userPrincipal.getId();
         log.info("회원 {}의 탈퇴를 요청받았습니다.", userId);
         myPageService.withdrawUser(userId, request, response);
         return ResponseEntity.ok(ApiResponse.success(
@@ -134,7 +134,7 @@ public class MyPageController {
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
             HttpServletRequest request, HttpServletResponse response
     ) {
-        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        Long userId = userPrincipal.getId();
         log.info("회원 {}의 로그아웃을 요청받았습니다.", userId);
         myPageService.logout(userId, request, response);
         return ResponseEntity.ok(ApiResponse.success(


### PR DESCRIPTION
## ✨ 작업 내용
- 마이페이지 API를 인증 사용자 기준으로 수정

---

## 📝 적용 범위
- `/global/config/security`
- `/mypage`

---

## 📌 참고 사항
- 관련 이슈 번호, 리뷰 시 유의사항 등을 적어주세요.