### PR TITLE
fix: 일일리포트의 조건부 아이콘이 사라지지 않는 현상 수정

### DIFF
--- a/src/main/java/com/example/emotion_storage/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/emotion_storage/report/repository/ReportRepository.java
@@ -51,4 +51,22 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
         return findLatestUnopenedReportIdsByUserId(userId, Pageable.ofSize(1))
                 .stream().findFirst();
     }
+
+    @Query("""
+        select r
+        from Report r
+        join r.timeCapsules tc
+        where tc.user.id = :userId
+        order by r.historyDate desc
+    """)
+    List<Report> findLatestReportsByUserId(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
+
+    default Optional<Report> findLatestReportByUserId(Long userId) {
+        return findLatestReportsByUserId(userId, Pageable.ofSize(1))
+                .stream()
+                .findFirst();
+    }
 }

--- a/src/main/java/com/example/emotion_storage/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/emotion_storage/report/repository/ReportRepository.java
@@ -36,4 +36,19 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     default Optional<Long> findLatestReportIdByUserId(Long userId) {
         return findLatestReportIdsByUserId(userId, Pageable.ofSize(1)).stream().findFirst();
     }
+
+    @Query("""
+        select distinct r.id
+        from Report r
+        join r.timeCapsules tc
+        where tc.user.id = :userId
+          and r.isOpened = false
+        order by r.historyDate desc
+    """)
+    List<Long> findLatestUnopenedReportIdsByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    default Optional<Long> findLatestUnopenedReportIdByUserId(Long userId) {
+        return findLatestUnopenedReportIdsByUserId(userId, Pageable.ofSize(1))
+                .stream().findFirst();
+    }
 }


### PR DESCRIPTION
## ✨ 작업 내용
- 일일리포트의 조건부 아이콘이 사라지지 않는 현상 수정
- 가장 최신 일일리포트를 확인한 경우에는 반환하지 않도록 변경

---

## 📝 적용 범위
- `/report`
- `/home`

---

## 📌 참고 사항
- 관련 이슈(Closed #157)