### PR TITLE
fix: 도착한 타임캡슐이 내역에 추가되지 않는 현상 수정

### DIFF
--- a/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
+++ b/src/main/java/com/example/emotion_storage/timecapsule/repository/TimeCapsuleRepository.java
@@ -61,9 +61,15 @@ public interface TimeCapsuleRepository extends JpaRepository<TimeCapsule, Long> 
     int countByUser_IdAndIsFavoriteTrue(Long userId);
 
     // 전체 유저에 대해 도착한 타임캡슐 조회에 사용
-    Page<TimeCapsule> findByDeletedAtIsNullAndIsTempSaveFalseAndIsOpenedFalseAndOpenedAtLessThanEqual(
-            LocalDateTime now, Pageable pageable
-    );
+    @Query("""
+    SELECT tc from TimeCapsule tc JOIN tc.user u
+    WHERE tc.deletedAt is null
+    AND tc.isTempSave is false
+    AND tc.isOpened is false
+    AND tc.openedAt <= :now
+    AND u.deletedAt is null
+    """)
+    Page<TimeCapsule> findArrivalTargetCapsules(@Param("now") LocalDateTime now, Pageable pageable);
 
     /**
      * 특정 사용자의 특정 날짜에 생성된 타임캡슐 목록 조회


### PR DESCRIPTION
## ✨ 작업 내용
- 도착 타임캡슐 조회 시 탈퇴 유저의 타임캡슐을 조회하지 않도록 구현
- 타임캡슐 알림 스케줄러에서 탈퇴 유저 예외 스킵 처리

---

## 📝 적용 범위
- `/notification`
- `/timecapsule`

---

## 📌 참고 사항
- 관련 이슈(Closed #161)