### PR TITLE
fix: Google OAuth clientIds 바인딩을 ConfigurationProperties로 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,8 @@ dependencies {
 	// WebSocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.java-websocket:Java-WebSocket:1.5.3'
+
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/emotion_storage/global/config/properties/GoogleOAuthProperties.java
+++ b/src/main/java/com/example/emotion_storage/global/config/properties/GoogleOAuthProperties.java
@@ -1,0 +1,25 @@
+package com.example.emotion_storage.global.config.properties;
+
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.security.oauth2.google")
+public class GoogleOAuthProperties {
+
+    private String clientIds;
+
+    public void setClientIds(String clientIds) {
+        this.clientIds = clientIds;
+    }
+
+    public List<String> getClientIdList() {
+        if (clientIds == null || clientIds.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(clientIds.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .toList();
+    }
+}

--- a/src/main/java/com/example/emotion_storage/global/config/properties/GoogleOAuthPropertiesConfig.java
+++ b/src/main/java/com/example/emotion_storage/global/config/properties/GoogleOAuthPropertiesConfig.java
@@ -1,0 +1,9 @@
+package com.example.emotion_storage.global.config.properties;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(GoogleOAuthProperties.class)
+public class GoogleOAuthPropertiesConfig {
+}

--- a/src/main/java/com/example/emotion_storage/user/auth/oauth/google/GoogleTokenVerifier.java
+++ b/src/main/java/com/example/emotion_storage/user/auth/oauth/google/GoogleTokenVerifier.java
@@ -1,5 +1,6 @@
 package com.example.emotion_storage.user.auth.oauth.google;
 
+import com.example.emotion_storage.global.config.properties.GoogleOAuthProperties;
 import com.example.emotion_storage.global.exception.BaseException;
 import com.example.emotion_storage.global.exception.ErrorCode;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
@@ -12,7 +13,6 @@ import java.security.GeneralSecurityException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -20,8 +20,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class GoogleTokenVerifier {
 
-    @Value("${spring.security.oauth2.google.client-ids}")
-    private List<String> googleClientIds;
+    private final GoogleOAuthProperties googleOAuthProperties;
 
     public GoogleLoginClaims verifyLoginToken(String idToken) {
         Payload payload = verifyToken(idToken);
@@ -37,10 +36,15 @@ public class GoogleTokenVerifier {
 
     public Payload verifyToken(String idToken) {
         try {
+            List<String> clientIds = googleOAuthProperties.getClientIdList();
+            if (clientIds.isEmpty()) {
+                throw new BaseException(ErrorCode.INVALID_ID_TOKEN);
+            }
+
             GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(
                     new NetHttpTransport(),
                     GsonFactory.getDefaultInstance())
-                    .setAudience(googleClientIds)
+                    .setAudience(clientIds)
                     .build();
 
             GoogleIdToken googleIdToken = verifier.verify(idToken);


### PR DESCRIPTION
## ✨ 작업 내용
- Google OAuth clientIds 바인딩을 ConfigurationProperties로 개선

---

## 📝 적용 범위
- `/global/config`
- `/users/auth/oauth/google`

---

## 📌 참고 사항
- 관련 이슈 번호, 리뷰 시 유의사항 등을 적어주세요.