### PR TITLE
fix: CI 테스트 타임존을 Asia/Seoul로 고정

### DIFF
--- a/.github/workflows/ci-production.yml
+++ b/.github/workflows/ci-production.yml
@@ -33,6 +33,7 @@ jobs:
 
     env:
       SPRING_PROFILES_ACTIVE: ci
+      TZ: Asia/Seoul
       CI_DB_HOST: 127.0.0.1
       CI_DB_PORT: 3306
       CI_DB_NAME: ci_db
@@ -65,7 +66,7 @@ jobs:
           exit 1
 
       - name: Run tests
-        run: ./gradlew test --stacktrace --info
+        run: ./gradlew test --stacktrace --info -Duser.timezone=Asia/Seoul
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-staging-auto.yml
+++ b/.github/workflows/deploy-staging-auto.yml
@@ -31,6 +31,7 @@ jobs:
 
     env:
       SPRING_PROFILES_ACTIVE: ci
+      TZ: Asia/Seoul
       CI_DB_HOST: 127.0.0.1
       CI_DB_PORT: 3306
       CI_DB_NAME: ci_db
@@ -63,7 +64,7 @@ jobs:
           exit 1
 
       - name: Run tests
-        run: ./gradlew test --stacktrace --info
+        run: ./gradlew test --stacktrace --info -Duser.timezone=Asia/Seoul
 
   build_and_deploy:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -82,4 +82,5 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	systemProperty "user.timezone", "Asia/Seoul"
 }


### PR DESCRIPTION
## ✨ 작업 내용
- CI 테스트 타임존을 Asia/Seoul로 고정

---

## 📝 적용 범위
- `build.gradle`
- `.github/workflows`

---

## 📌 참고 사항
- 관련 이슈 번호, 리뷰 시 유의사항 등을 적어주세요.