### PR TITLE
fix: CI MySQL 데이터베이스 시간대 Asia/Seoul로 통일

### DIFF
--- a/src/main/resources/application-ci.yml
+++ b/src/main/resources/application-ci.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${CI_DB_HOST:localhost}:${CI_DB_PORT:3306}/${CI_DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8
+    url: jdbc:mysql://${CI_DB_HOST:localhost}:${CI_DB_PORT:3306}/${CI_DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&sessionVariables=time_zone='%2B09:00'&characterEncoding=UTF-8
     username: ${CI_DB_USER}
     password: ${CI_DB_PASSWORD}
 


### PR DESCRIPTION
## ✨ 작업 내용
- CI MySQL 데이터베이스 시간대 Asia/Seoul로 통일

---

## 📝 적용 범위
- `/resources`

---

## 📌 참고 사항
- 관련 이슈 번호, 리뷰 시 유의사항 등을 적어주세요.