### PR TITLE
fix: github actions gradle run multiline으로 JVM 옵션 인식 수정

### DIFF
--- a/.github/workflows/deploy-staging-auto.yml
+++ b/.github/workflows/deploy-staging-auto.yml
@@ -64,12 +64,13 @@ jobs:
           exit 1
 
       - name: Run tests
-        run: ./gradlew test --stacktrace --info \
-          -Duser.timezone=Asia/Seoul \
-          -Dspring.profiles.active=test \
-          -Dlogging.level.org.hibernate.SQL=DEBUG \
-          -Dlogging.level.org.hibernate.orm.jdbc.bind=TRACE \
-          -Dlogging.level.org.springframework.transaction=TRACE
+        run: |
+          ./gradlew test --stacktrace --info \
+            -Duser.timezone=Asia/Seoul \
+            -Dspring.profiles.active=test \
+            -Dlogging.level.org.hibernate.SQL=DEBUG \
+            -Dlogging.level.org.hibernate.orm.jdbc.bind=TRACE \
+            -Dlogging.level.org.springframework.transaction=TRACE
 
       - name: Upload test reports
         if: always()


### PR DESCRIPTION
## ✨ 작업 내용
- github actions gradle run multiline으로 JVM 옵션 인식 수정

---

## 📝 적용 범위
- `.github/workflows`

---

## 📌 참고 사항
- 관련 이슈 번호, 리뷰 시 유의사항 등을 적어주세요.