### PR TITLE
test: 채팅방 재사용 테스트에서 당일 첫 채팅 여부 검증 제거

### DIFF
--- a/src/test/java/com/example/emotion_storage/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/example/emotion_storage/chat/service/ChatServiceTest.java
@@ -161,7 +161,6 @@ public class ChatServiceTest {
         assertThat(response.roomId()).isNotNull();
         assertThat(response.roomId()).isEqualTo(chatRoom.getId());
         assertThat(response.isTempSave()).isFalse();
-        assertThat(response.isFirstChatOfDay()).isTrue();
         assertThat(chatRoom.getUser().getId()).isEqualTo(userId);
         assertThat(chatRoom.isEnded()).isFalse();
     }
@@ -180,7 +179,6 @@ public class ChatServiceTest {
         assertThat(response.roomId()).isNotNull();
         assertThat(response.roomId()).isEqualTo(chatRoom.getId());
         assertThat(response.isTempSave()).isTrue();
-        assertThat(response.isFirstChatOfDay()).isTrue();
         assertThat(chatRoom.getUser().getId()).isEqualTo(userId);
         assertThat(chatRoom.isEnded()).isFalse();
     }


### PR DESCRIPTION
## ✨ 작업 내용
- 채팅방 재사용 테스트에서 당일 첫 채팅 여부 검증 제거

---

## 📝 적용 범위
- `src/test/java/com/example/emotion_storage/chat/service/ChatServiceTest.java`

---

## 📌 참고 사항
- 관련 이슈 번호, 리뷰 시 유의사항 등을 적어주세요.