### PR TITLE
feat: 타임캡슐 및 일일리포트 존재 날짜 반환 API 구현

### DIFF
--- a/src/main/java/com/example/emotion_storage/calendar/controller/CalendarController.java
+++ b/src/main/java/com/example/emotion_storage/calendar/controller/CalendarController.java
@@ -1,0 +1,43 @@
+package com.example.emotion_storage.calendar.controller;
+
+import com.example.emotion_storage.calendar.dto.response.CalendarFilledDatesResponse;
+import com.example.emotion_storage.calendar.service.CalendarService;
+import com.example.emotion_storage.global.api.ApiResponse;
+import com.example.emotion_storage.global.api.SuccessMessage;
+import com.example.emotion_storage.global.security.principal.CustomUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/calendar")
+@RequiredArgsConstructor
+@Tag(name = "Calendar", description = "캘린더 관련 API")
+public class CalendarController {
+
+    private final CalendarService calendarService;
+
+    @GetMapping("/date")
+    @Operation(
+            summary = "캘린더 상 타임캡슐 및 일일리포트 존재 날짜 조회",
+            description = "yyyy년 MM월의 날짜 중 타임캡슐 또는 일일리포트가 존재하는 날짜 목록을 반환합니다."
+    )
+    public ResponseEntity<ApiResponse<CalendarFilledDatesResponse>> getCalendarFilledDates(
+            @RequestParam int year, @RequestParam int month, @AuthenticationPrincipal CustomUserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal != null ? userPrincipal.getId() : 1L; // TODO: 개발 테스트를 위한 코드
+        log.info("사용자 {}의 {}년 {}월의 타임캡슐 및 일일리포트 목록 조회를 요청받았습니다.", userId, year, month);
+        CalendarFilledDatesResponse response = calendarService.getExistDates(year, month, userId);
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessMessage.GET_CALENDAR_DATES_SUCCESS.getMessage(), response)
+        );
+    }
+}

--- a/src/main/java/com/example/emotion_storage/calendar/dto/response/CalendarFilledDatesResponse.java
+++ b/src/main/java/com/example/emotion_storage/calendar/dto/response/CalendarFilledDatesResponse.java
@@ -1,0 +1,9 @@
+package com.example.emotion_storage.calendar.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CalendarFilledDatesResponse(
+        int totalDates,
+        List<LocalDate> dates
+) {}

--- a/src/main/java/com/example/emotion_storage/calendar/service/CalendarService.java
+++ b/src/main/java/com/example/emotion_storage/calendar/service/CalendarService.java
@@ -1,0 +1,52 @@
+package com.example.emotion_storage.calendar.service;
+
+import com.example.emotion_storage.calendar.dto.response.CalendarFilledDatesResponse;
+import com.example.emotion_storage.report.repository.ReportRepository;
+import com.example.emotion_storage.timecapsule.repository.TimeCapsuleRepository;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CalendarService {
+
+    private final TimeCapsuleRepository timeCapsuleRepository;
+    private final ReportRepository reportRepository;
+
+    public CalendarFilledDatesResponse getExistDates(
+            int year, int month, Long userId
+    ) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDateTime start = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime end = yearMonth.plusMonths(1).atDay(1).atStartOfDay();
+
+        log.info("{}년 {}월에 타임캡슐이 존재하는 날짜 목록을 조회합니다.", year, month);
+        List<LocalDate> timeCapsuleDates =
+                timeCapsuleRepository.findActiveDatesInRange(userId, start, end).stream()
+                        .map(Date::toLocalDate)
+                        .toList();
+
+        log.info("{}년 {}월에 일일리포트가 존재하는 날짜 목록을 조회합니다.", year, month);
+        List<LocalDate> reportDates =
+                reportRepository.findActiveDatesInRange(userId, start.toLocalDate(), end.toLocalDate());
+
+        log.info("{}년 {}월에 존재하는 타임캡슐과 일일리포트의 날짜 목록을 종합합니다.", year, month);
+        Set<LocalDate> mergedDates = new HashSet<>();
+        mergedDates.addAll(timeCapsuleDates);
+        mergedDates.addAll(reportDates);
+
+        List<LocalDate> dates = mergedDates.stream()
+                .sorted()
+                .toList();
+        return new CalendarFilledDatesResponse(dates.size(), dates);
+    }
+}

--- a/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
+++ b/src/main/java/com/example/emotion_storage/global/api/SuccessMessage.java
@@ -62,6 +62,9 @@ public enum SuccessMessage {
 
     // Notification
     GET_NOTIFICATION_LIST_SUCCESS("알림 목록 조회 성공"),
+
+    // Calendar
+    GET_CALENDAR_DATES_SUCCESS("월별 타임캡슐 및 일일리포트 날짜 목록 조회 성공"),
     ;
 
     private final String message;

--- a/src/main/java/com/example/emotion_storage/report/domain/Report.java
+++ b/src/main/java/com/example/emotion_storage/report/domain/Report.java
@@ -2,6 +2,7 @@ package com.example.emotion_storage.report.domain;
 
 import com.example.emotion_storage.global.entity.BaseTimeEntity;
 import com.example.emotion_storage.timecapsule.domain.TimeCapsule;
+import com.example.emotion_storage.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -21,6 +22,10 @@ public class Report extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "report_id")
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @Column(nullable = false)
     private LocalDate historyDate;

--- a/src/main/java/com/example/emotion_storage/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/emotion_storage/report/repository/ReportRepository.java
@@ -14,21 +14,18 @@ import java.util.Optional;
 @Repository
 public interface ReportRepository extends JpaRepository<Report, Long> {
     
-    @Query("SELECT COUNT(DISTINCT r) FROM Report r " +
-           "JOIN r.timeCapsules tc " +
-           "WHERE tc.user.id = :userId AND r.isOpened = false")
+    @Query("SELECT COUNT(r) FROM Report r " +
+           "WHERE r.user.id = :userId AND r.isOpened = false")
     Long countUnopenedReportsByUserId(@Param("userId") Long userId);
     
-    @Query("SELECT DISTINCT r FROM Report r " +
-           "JOIN r.timeCapsules tc " +
-           "WHERE tc.user.id = :userId AND r.historyDate = :historyDate")
+    @Query("SELECT r FROM Report r " +
+           "WHERE r.user.id = :userId AND r.historyDate = :historyDate")
     Optional<Report> findByUserIdAndHistoryDate(@Param("userId") Long userId, @Param("historyDate") LocalDate historyDate);
 
     @Query("""
-        select distinct r.id
+        select r.id
         from Report r
-        join r.timeCapsules tc
-        where tc.user.id = :userId
+        where r.user.id = :userId
         order by r.historyDate desc
     """)
     List<Long> findLatestReportIdsByUserId(@Param("userId") Long userId, Pageable pageable);
@@ -38,10 +35,9 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     }
 
     @Query("""
-        select distinct r.id
+        select r.id
         from Report r
-        join r.timeCapsules tc
-        where tc.user.id = :userId
+        where r.user.id = :userId
           and r.isOpened = false
         order by r.historyDate desc
     """)
@@ -55,8 +51,7 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     @Query("""
         select r
         from Report r
-        join r.timeCapsules tc
-        where tc.user.id = :userId
+        where r.user.id = :userId
         order by r.historyDate desc
     """)
     List<Report> findLatestReportsByUserId(

--- a/src/main/java/com/example/emotion_storage/report/repository/ReportRepository.java
+++ b/src/main/java/com/example/emotion_storage/report/repository/ReportRepository.java
@@ -64,4 +64,10 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
                 .stream()
                 .findFirst();
     }
+
+    @Query("SELECT DISTINCT r.historyDate from Report r "
+            + "WHERE r.user.id = :userId AND r.historyDate >= :start AND r.historyDate < :end "
+            + "ORDER BY r.historyDate")
+    List<LocalDate> findActiveDatesInRange(@Param("userId") Long userId, @Param("start") LocalDate start, @Param("end") LocalDate end);
+
 }

--- a/src/main/java/com/example/emotion_storage/report/service/DailyReportGenerateService.java
+++ b/src/main/java/com/example/emotion_storage/report/service/DailyReportGenerateService.java
@@ -259,6 +259,7 @@ public class DailyReportGenerateService {
         
         // Report 생성
         Report report = Report.builder()
+                .user(user)
                 .historyDate(historyDate)
                 .todaySummary(todaySummary)
                 .stressIndex(aiResponse.getStressLevel())

--- a/src/main/java/com/example/emotion_storage/user/auth/oauth/google/GoogleTokenVerifier.java
+++ b/src/main/java/com/example/emotion_storage/user/auth/oauth/google/GoogleTokenVerifier.java
@@ -1,6 +1,6 @@
 package com.example.emotion_storage.user.auth.oauth.google;
 
-import com.example.emotion_storage.global.config.properties.GoogleOAuthProperties;
+import com.example.emotion_storage.user.auth.oauth.google.config.GoogleOAuthProperties;
 import com.example.emotion_storage.global.exception.BaseException;
 import com.example.emotion_storage.global.exception.ErrorCode;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;

--- a/src/main/java/com/example/emotion_storage/user/auth/oauth/google/config/GoogleOAuthProperties.java
+++ b/src/main/java/com/example/emotion_storage/user/auth/oauth/google/config/GoogleOAuthProperties.java
@@ -1,4 +1,4 @@
-package com.example.emotion_storage.global.config.properties;
+package com.example.emotion_storage.user.auth.oauth.google.config;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/com/example/emotion_storage/user/auth/oauth/google/config/GoogleOAuthPropertiesConfig.java
+++ b/src/main/java/com/example/emotion_storage/user/auth/oauth/google/config/GoogleOAuthPropertiesConfig.java
@@ -1,4 +1,4 @@
-package com.example.emotion_storage.global.config.properties;
+package com.example.emotion_storage.user.auth.oauth.google.config;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/resources/db/migration/V3__add_user_id_to_reports.sql
+++ b/src/main/resources/db/migration/V3__add_user_id_to_reports.sql
@@ -1,0 +1,14 @@
+-- 1) nullable 로 컬럼 추가
+ALTER TABLE reports
+    ADD COLUMN user_id BIGINT NULL;
+
+-- 2) 기존 report.user_id 채우기
+-- Report는 time_capsules.report_id로 연결되어 있고 time_capsules.user_id로 유저 확인 가능
+UPDATE reports r
+    JOIN (
+    SELECT tc.report_id, MIN(tc.user_id) AS user_id
+    FROM time_capsules tc
+    WHERE tc.report_id IS NOT NULL
+    GROUP BY tc.report_id
+    ) x ON x.report_id = r.report_id
+    SET r.user_id = x.user_id;


### PR DESCRIPTION
## ✨ 작업 내용
- reports 테이블에 user_id 컬럼 추가 및 기존 데이터 백필
- Report 엔티티에 user 연관관계 매핑 추가
- 리포트 조회 로직을 타임캡슐 조인 기준에서 사용자 기준으로 변경
- 타임캡슐 및 일일리포트 존재 날짜를 종합하는 캘린더 filled 날짜 조회 API 구현

---

## 📝 적용 범위
- `/calendar`
- `/report` 

---

## 📌 참고 사항
- 관련 이슈(Closed #188)