### PR TITLE
fix: 첫 대화 여부 판단 시 현재 채팅방이 prevRoom에 포함되는 케이스 방어

### DIFF
--- a/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
+++ b/src/main/java/com/example/emotion_storage/chat/service/ChatService.java
@@ -142,6 +142,10 @@ public class ChatService {
                 currentRoom.getUser().getId(), currentRoom.getCreatedAt(), currentRoom.getId(), PageRequest.of(0, 1)
         );
 
+        prevRooms = prevRooms.stream()
+                .filter(r -> !r.getId().equals(currentRoom.getId()))
+                .toList();
+
         if (prevRooms.isEmpty()) {
             log.info("이전 채팅방이 존재하지 않기 때문에 첫 대화방으로 판단합니다.");
             return true;


### PR DESCRIPTION
## ✨ 작업 내용
- 첫 대화 여부 판단 시 현재 채팅방이 prevRoom에 포함되는 케이스 방어

---

## 📝 적용 범위
- `/chat`

---

## 📌 참고 사항
- 관련 이슈 번호, 리뷰 시 유의사항 등을 적어주세요.