### PR TITLE
refactor: 배치 스케줄러 사용자 처리 방식 개선 (티켓 초기화/일일 리포트)

### DIFF
--- a/src/main/java/com/example/emotion_storage/report/service/DailyReportGenerateService.java
+++ b/src/main/java/com/example/emotion_storage/report/service/DailyReportGenerateService.java
@@ -62,23 +62,23 @@ public class DailyReportGenerateService {
         log.info("일일 리포트 생성 스케줄러 시작 - 대상 날짜: {}", yesterday);
         
         try {
-            List<User> activeUsers = userRepository.findAllActiveUsers();
-            log.info("활성 사용자 수: {}", activeUsers.size());
+            List<Long> activeUserIds = userRepository.findAllActiveUserIdsWithValidGender();
+            log.info("리포트 생성 대상 사용자 수(유효 성별): {}", activeUserIds.size());
             
             int successCount = 0;
             int skipCount = 0;
             int errorCount = 0;
             
-            for (User user : activeUsers) {
+            for (Long userId : activeUserIds) {
                 try {
-                    boolean generated = generateDailyReportForUser(user, yesterday);
+                    boolean generated = generateDailyReportForUser(userId, yesterday);
                     if (generated) {
                         successCount++;
                     } else {
                         skipCount++;
                     }
                 } catch (Exception e) {
-                    log.error("사용자 ID {}의 일일 리포트 생성 중 오류 발생", user.getId(), e);
+                    log.error("사용자 ID {}의 일일 리포트 생성 중 오류 발생", userId, e);
                     errorCount++;
                 }
             }
@@ -95,13 +95,13 @@ public class DailyReportGenerateService {
      * 특정 사용자에 대해 전날 타임캡슐을 종합하여 일일 리포트 생성
      */
     @Transactional
-    public boolean generateDailyReportForUser(User user, LocalDate targetDate) {
-        log.info("일일 리포트 생성 시작 - userId: {}, date: {}", user.getId(), targetDate);
+    public boolean generateDailyReportForUser(Long userId, LocalDate targetDate) {
+        log.info("일일 리포트 생성 시작 - userId: {}, date: {}", userId, targetDate);
         
         // 이미 리포트가 존재하는지 확인
-        boolean reportExists = reportRepository.findByUserIdAndHistoryDate(user.getId(), targetDate).isPresent();
+        boolean reportExists = reportRepository.findByUserIdAndHistoryDate(userId, targetDate).isPresent();
         if (reportExists) {
-            log.info("이미 존재하는 리포트 - userId: {}, date: {}", user.getId(), targetDate);
+            log.info("이미 존재하는 리포트 - userId: {}, date: {}", userId, targetDate);
             return false;
         }
         
@@ -109,17 +109,17 @@ public class DailyReportGenerateService {
         LocalDateTime startOfDay = targetDate.atStartOfDay();
         LocalDateTime startOfNextDay = targetDate.plusDays(1).atStartOfDay();
         List<TimeCapsule> timeCapsules = timeCapsuleRepository.findByUserIdAndHistoryDate(
-                user.getId(),
+                userId,
                 startOfDay,
                 startOfNextDay
         );
         
         if (timeCapsules.isEmpty()) {
-            log.info("타임캡슐이 없어 리포트 생성 스킵 - userId: {}, date: {}", user.getId(), targetDate);
+            log.info("타임캡슐이 없어 리포트 생성 스킵 - userId: {}, date: {}", userId, targetDate);
             return false;
         }
         
-        log.info("타임캡슐 발견 - userId: {}, date: {}, count: {}", user.getId(), targetDate, timeCapsules.size());
+        log.info("타임캡슐 발견 - userId: {}, date: {}, count: {}", userId, targetDate, timeCapsules.size());
         
         // 타임캡슐 정보를 문자열로 변환
         String referenceMessage = buildReferenceMessage(timeCapsules);
@@ -128,14 +128,15 @@ public class DailyReportGenerateService {
         DailyReportGenerateResponse aiResponse = callAiServer(referenceMessage);
         
         // AI 응답을 Report 엔티티로 변환하여 저장
-        Report report = convertToReport(user, targetDate, timeCapsules, aiResponse);
+        User reportOwner = userRepository.getReferenceById(userId);
+        Report report = convertToReport(reportOwner, targetDate, timeCapsules, aiResponse);
         reportRepository.save(report);
 
         // 알림 저장
-        notificationService.createDailyReportArrival(user.getId(), report.getId());
+        notificationService.createDailyReportArrival(userId, report.getId());
         
         log.info("일일 리포트 생성 완료 - userId: {}, date: {}, reportId: {}", 
-                user.getId(), targetDate, report.getId());
+                userId, targetDate, report.getId());
         
         return true;
     }
@@ -338,4 +339,3 @@ public class DailyReportGenerateService {
         }
     }
 }
-

--- a/src/main/java/com/example/emotion_storage/user/repository/UserRepository.java
+++ b/src/main/java/com/example/emotion_storage/user/repository/UserRepository.java
@@ -21,6 +21,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u WHERE u.deletedAt IS NULL")
     List<User> findAllActiveUsers();
 
+    @Query(
+            value = "SELECT user_id FROM users WHERE deleted_at IS NULL AND gender IN ('MALE', 'FEMALE')",
+            nativeQuery = true
+    )
+    List<Long> findAllActiveUserIdsWithValidGender();
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE User u SET u.ticketCount = :ticketCount WHERE u.deletedAt IS NULL")
     int resetTicketCountForAllActiveUsers(@Param("ticketCount") Long ticketCount);

--- a/src/main/java/com/example/emotion_storage/user/repository/UserRepository.java
+++ b/src/main/java/com/example/emotion_storage/user/repository/UserRepository.java
@@ -5,6 +5,7 @@ import com.example.emotion_storage.user.domain.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -19,4 +20,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     
     @Query("SELECT u FROM User u WHERE u.deletedAt IS NULL")
     List<User> findAllActiveUsers();
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE User u SET u.ticketCount = :ticketCount WHERE u.deletedAt IS NULL")
+    int resetTicketCountForAllActiveUsers(@Param("ticketCount") Long ticketCount);
 }

--- a/src/main/java/com/example/emotion_storage/user/service/TicketInitService.java
+++ b/src/main/java/com/example/emotion_storage/user/service/TicketInitService.java
@@ -1,10 +1,8 @@
 package com.example.emotion_storage.user.service;
 
-import com.example.emotion_storage.user.domain.User;
 import com.example.emotion_storage.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -27,18 +25,8 @@ public class TicketInitService {
         log.info("티켓 초기화 스케줄러 시작 - 시간: {}", LocalDateTime.now(ZoneId.of("Asia/Seoul")));
         
         try {
-            List<User> activeUsers = userRepository.findAllActiveUsers();
-            log.info("활성 사용자 수: {}", activeUsers.size());
-            
-            int initCount = 0;
-            for (User user : activeUsers) {
-                user.initTicketCount();
-                initCount++;
-            }
-            
-            userRepository.saveAll(activeUsers);
-            
-            log.info("티켓 초기화 완료 - 처리된 사용자 수: {}", initCount);
+            int updatedCount = userRepository.resetTicketCountForAllActiveUsers(10L);
+            log.info("티켓 초기화 완료 - 처리된 사용자 수: {}", updatedCount);
             
         } catch (Exception e) {
             log.error("티켓 초기화 중 오류 발생", e);


### PR DESCRIPTION
## ✨ 작업 내용
- 티켓 초기화 배치를 사용자 엔티티 조회/순회 방식에서 벌크 업데이트 방식으로 변경
- 일일 리포트 배치를 `User` 엔티티 리스트 기반 처리에서 `userId` 기반 처리로 변경
- 일일 리포트 대상 사용자 조회에 유효 gender 조건을 적용해, 배치 중단을 유발할 수 있는 데이터를 대상에서 제외하도록 정리

---

## 📝 적용 범위
- `src/main/java/com/example/emotion_storage/user/repository/UserRepository.java`
- `src/main/java/com/example/emotion_storage/user/service/TicketInitService.java`
- `src/main/java/com/example/emotion_storage/report/service/DailyReportGenerateService.java`

---

## 📌 참고 사항
- 관련 이슈: Closed #196 